### PR TITLE
Removed try catch block, allow exception to bubble

### DIFF
--- a/src/tournamentEngine/async.js
+++ b/src/tournamentEngine/async.js
@@ -154,17 +154,13 @@ export function tournamentEngineAsync() {
 
             return result;
           } else {
-            try {
-              const result = await engineInvoke(
-                governor[governorMethod],
-                params,
-                governorMethod
-              );
+            const result = await engineInvoke(
+              governor[governorMethod],
+              params,
+              governorMethod
+            );
 
-              return result;
-            } catch (err) {
-              console.log('%c ERROR', 'color: orange', { err });
-            }
+            return result;
           }
         };
       }


### PR DESCRIPTION
I want top level exceptions to bubble outside tournament-engine. So I can process them acordingly.
For example if exception is thrown in event handler, tournament engine will catch it and exit gracefully.
This prevents me from catching exception and doing action on it, eg. retryible transaction error..