### PR TITLE
Fixed getSeeding when seedAssignments is undefined

### DIFF
--- a/src/drawEngine/getters/getMatchUps/getSide.js
+++ b/src/drawEngine/getters/getMatchUps/getSide.js
@@ -80,7 +80,7 @@ function getSideValue({
 }
 
 function getSeeding({ seedAssignments, participantId }) {
-  return seedAssignments.find(
+  return seedAssignments?.find(
     (assignment) =>
       !assignment.seedProxy && assignment.participantId === participantId
   );


### PR DESCRIPTION
The getSeeding function was throwing an exception when seedAssignments was undefined in the TODs structure.