### PR TITLE
feat: updated logic for collections gender validation

### DIFF
--- a/documentation/docs/utilities/utilities-api.md
+++ b/documentation/docs/utilities/utilities-api.md
@@ -87,18 +87,6 @@ const { extension } = utilities.findExtension({ element, name });
 
 ---
 
-## genderValidityCheck
-
-```js
-const { valid, error } = utilities.genderValidityCheck({
-  referenceGender, // if not present then always returns { valid: true }
-  matchUpType, // optional - check whether matchUpType is valid for referenceGender
-  gender,
-});
-```
-
----
-
 ## generateHashCode
 
 ---
@@ -230,6 +218,19 @@ const {
 ---
 
 ## tidyScore
+
+---
+
+## tieFormatGenderValidityCheck
+
+```js
+const { valid, error } = utilities.tieFormatGenderValidityCheck({
+  referenceGender, // if not present then always returns { valid: true }
+  referenceEvent, // required when { eventType: MIXED }
+  matchUpType, // optional - check whether matchUpType is valid for referenceGender
+  gender,
+});
+```
 
 ---
 

--- a/src/global/tests/genderValidityCheck.test.ts
+++ b/src/global/tests/genderValidityCheck.test.ts
@@ -5,8 +5,6 @@ import { DOUBLES_MATCHUP, SINGLES_MATCHUP } from '../../constants/matchUpTypes';
 import { INVALID_GENDER } from '../../constants/errorConditionConstants';
 import { GenderEnum } from '../../types/tournamentFromSchema';
 
-const errorInfo = 'MIXED events can only contain MIXED doubles collections';
-
 const scenarios = [
   {
     params: {
@@ -41,6 +39,30 @@ const scenarios = [
   },
   {
     params: {
+      referenceGender: GenderEnum.Male,
+      gender: GenderEnum.Female,
+    },
+    expectation: {
+      error: INVALID_GENDER,
+      stack: ['genderValidityCheck'],
+      gender: 'FEMALE',
+      valid: false,
+    },
+  },
+  {
+    params: {
+      referenceGender: GenderEnum.Female,
+      gender: GenderEnum.Male,
+    },
+    expectation: {
+      error: INVALID_GENDER,
+      stack: ['genderValidityCheck'],
+      gender: 'MALE',
+      valid: false,
+    },
+  },
+  {
+    params: {
       referenceGender: GenderEnum.Female,
       gender: GenderEnum.Mixed,
     },
@@ -60,96 +82,137 @@ const scenarios = [
   },
   {
     params: {
-      referenceGender: GenderEnum.Any,
-      matchUpType: DOUBLES_MATCHUP,
-      gender: GenderEnum.Female,
-    },
-    expectation: { valid: true },
-  },
-  {
-    params: {
-      referenceGender: GenderEnum.Any,
-      matchUpType: SINGLES_MATCHUP,
-      gender: GenderEnum.Female,
-    },
-    expectation: { valid: true },
-  },
-  {
-    params: {
-      referenceGender: GenderEnum.Any,
-      matchUpType: SINGLES_MATCHUP,
-      gender: GenderEnum.Mixed,
-    },
-    expectation: { valid: true },
-  },
-  {
-    params: {
-      referenceGender: GenderEnum.Mixed,
-      matchUpType: SINGLES_MATCHUP,
-      gender: GenderEnum.Mixed,
-    },
-    expectation: {
-      error: INVALID_GENDER,
-      stack: ['genderValidityCheck'],
-      info: errorInfo,
-      valid: false,
-    },
-  },
-  {
-    params: {
-      referenceGender: GenderEnum.Mixed,
-      matchUpType: DOUBLES_MATCHUP,
-      gender: GenderEnum.Mixed,
-    },
-    expectation: { valid: true },
-  },
-  {
-    params: {
-      referenceGender: GenderEnum.Mixed,
-      matchUpType: DOUBLES_MATCHUP,
-      gender: GenderEnum.Female,
-    },
-    expectation: {
-      error: INVALID_GENDER,
-      stack: ['genderValidityCheck'],
-      info: errorInfo,
-      valid: false,
-    },
-  },
-  {
-    params: {
-      referenceGender: GenderEnum.Mixed,
-      matchUpType: SINGLES_MATCHUP,
-      gender: GenderEnum.Female,
-    },
-    expectation: {
-      stack: ['genderValidityCheck'],
-      error: INVALID_GENDER,
-      info: errorInfo,
-      valid: false,
-    },
-  },
-  {
-    params: {
       referenceGender: GenderEnum.Female,
+      gender: GenderEnum.Any,
+    },
+    expectation: {
+      error: INVALID_GENDER,
+      stack: ['genderValidityCheck'],
+      gender: 'ANY',
+      valid: false,
+    },
+  },
+  {
+    params: {
+      referenceGender: GenderEnum.Any,
+      matchUpType: DOUBLES_MATCHUP,
+      gender: GenderEnum.Female,
+    },
+    expectation: { valid: true },
+  },
+  {
+    params: {
+      referenceGender: GenderEnum.Any,
+      matchUpType: SINGLES_MATCHUP,
+      gender: GenderEnum.Female,
+    },
+    expectation: { valid: true },
+  },
+  {
+    params: {
+      referenceGender: GenderEnum.Any,
+      matchUpType: SINGLES_MATCHUP,
+      gender: GenderEnum.Mixed,
+    },
+    expectation: {
+      error: INVALID_GENDER,
+      stack: ['genderValidityCheck'],
+      info: 'COED events can not contain MIXED singles collections',
+      valid: false,
+    },
+  },
+  {
+    params: {
+      referenceGender: GenderEnum.Any,
+      matchUpType: DOUBLES_MATCHUP,
+      gender: GenderEnum.Mixed,
+    },
+    expectation: { valid: true },
+  },
+  {
+    params: {
+      referenceGender: GenderEnum.Any,
+      matchUpType: DOUBLES_MATCHUP,
       gender: GenderEnum.Male,
     },
+    expectation: { valid: true },
+  },
+  {
+    params: {
+      referenceGender: GenderEnum.Mixed,
+      matchUpType: SINGLES_MATCHUP,
+      gender: GenderEnum.Mixed,
+    },
     expectation: {
-      stack: ['genderValidityCheck'],
       error: INVALID_GENDER,
-      gender: 'MALE',
+      stack: ['genderValidityCheck'],
+      info: 'MIXED events can not contain mixed singles or coed collections',
       valid: false,
     },
   },
   {
     params: {
-      referenceGender: GenderEnum.Male,
+      referenceGender: GenderEnum.Mixed,
+      matchUpType: DOUBLES_MATCHUP,
+      gender: GenderEnum.Mixed,
+    },
+    expectation: { valid: true },
+  },
+  {
+    params: {
+      referenceGender: GenderEnum.Mixed,
+      matchUpType: DOUBLES_MATCHUP,
       gender: GenderEnum.Female,
     },
+    expectation: { valid: true },
+  },
+  {
+    params: {
+      referenceGender: GenderEnum.Mixed,
+      matchUpType: SINGLES_MATCHUP,
+      gender: GenderEnum.Female,
+    },
+    expectation: { valid: true },
+  },
+  {
+    params: {
+      referenceGender: GenderEnum.Mixed,
+      matchUpType: SINGLES_MATCHUP,
+      gender: GenderEnum.Male,
+    },
+    expectation: { valid: true },
+  },
+  {
+    params: {
+      referenceGender: GenderEnum.Mixed,
+      matchUpType: DOUBLES_MATCHUP,
+      gender: GenderEnum.Male,
+    },
+    expectation: { valid: true },
+  },
+  {
+    params: {
+      referenceGender: GenderEnum.Mixed,
+      matchUpType: SINGLES_MATCHUP,
+      gender: GenderEnum.Any,
+    },
     expectation: {
-      stack: ['genderValidityCheck'],
       error: INVALID_GENDER,
-      gender: 'FEMALE',
+      stack: ['genderValidityCheck'],
+      info: 'MIXED events can not contain mixed singles or coed collections',
+      valid: false,
+    },
+  },
+  {
+    params: {
+      referenceGender: GenderEnum.Mixed,
+      matchUpType: DOUBLES_MATCHUP,
+      gender: GenderEnum.Any,
+    },
+    expectation: {
+      error: INVALID_GENDER,
+      stack: ['genderValidityCheck'],
+      info: 'MIXED events can not contain mixed singles or coed collections',
       valid: false,
     },
   },

--- a/src/global/tests/tieFormatGenderValidityCheck.test.ts
+++ b/src/global/tests/tieFormatGenderValidityCheck.test.ts
@@ -1,9 +1,15 @@
-import { genderValidityCheck } from '../functions/deducers/genderValidityCheck';
 import { expect, it } from 'vitest';
+import {
+  anyMixedError,
+  tieFormatGenderValidityCheck,
+  mixedGenderError,
+} from '../functions/deducers/tieFormatGenderValidityCheck';
 
 import { DOUBLES_MATCHUP, SINGLES_MATCHUP } from '../../constants/matchUpTypes';
 import { INVALID_GENDER } from '../../constants/errorConditionConstants';
-import { GenderEnum } from '../../types/tournamentFromSchema';
+import { GenderEnum, TypeEnum } from '../../types/tournamentFromSchema';
+
+const referenceEvent = { eventType: TypeEnum.Team, eventId: 'eventId' };
 
 const scenarios = [
   {
@@ -19,8 +25,8 @@ const scenarios = [
       gender: GenderEnum.Mixed,
     },
     expectation: {
+      stack: ['tieFormatGenderValidityCheck'],
       error: INVALID_GENDER,
-      stack: ['genderValidityCheck'],
       gender: 'MIXED',
       valid: false,
     },
@@ -31,8 +37,8 @@ const scenarios = [
       gender: GenderEnum.Any,
     },
     expectation: {
+      stack: ['tieFormatGenderValidityCheck'],
       error: INVALID_GENDER,
-      stack: ['genderValidityCheck'],
       gender: 'ANY',
       valid: false,
     },
@@ -43,8 +49,8 @@ const scenarios = [
       gender: GenderEnum.Female,
     },
     expectation: {
+      stack: ['tieFormatGenderValidityCheck'],
       error: INVALID_GENDER,
-      stack: ['genderValidityCheck'],
       gender: 'FEMALE',
       valid: false,
     },
@@ -55,8 +61,8 @@ const scenarios = [
       gender: GenderEnum.Male,
     },
     expectation: {
+      stack: ['tieFormatGenderValidityCheck'],
       error: INVALID_GENDER,
-      stack: ['genderValidityCheck'],
       gender: 'MALE',
       valid: false,
     },
@@ -67,8 +73,8 @@ const scenarios = [
       gender: GenderEnum.Mixed,
     },
     expectation: {
+      stack: ['tieFormatGenderValidityCheck'],
       error: INVALID_GENDER,
-      stack: ['genderValidityCheck'],
       gender: 'MIXED',
       valid: false,
     },
@@ -86,8 +92,8 @@ const scenarios = [
       gender: GenderEnum.Any,
     },
     expectation: {
+      stack: ['tieFormatGenderValidityCheck'],
       error: INVALID_GENDER,
-      stack: ['genderValidityCheck'],
       gender: 'ANY',
       valid: false,
     },
@@ -115,9 +121,9 @@ const scenarios = [
       gender: GenderEnum.Mixed,
     },
     expectation: {
+      info: anyMixedError,
+      stack: ['tieFormatGenderValidityCheck'],
       error: INVALID_GENDER,
-      stack: ['genderValidityCheck'],
-      info: 'COED events can not contain MIXED singles collections',
       valid: false,
     },
   },
@@ -144,9 +150,9 @@ const scenarios = [
       gender: GenderEnum.Mixed,
     },
     expectation: {
+      stack: ['tieFormatGenderValidityCheck'],
       error: INVALID_GENDER,
-      stack: ['genderValidityCheck'],
-      info: 'MIXED events can not contain mixed singles or coed collections',
+      info: mixedGenderError,
       valid: false,
     },
   },
@@ -155,6 +161,7 @@ const scenarios = [
       referenceGender: GenderEnum.Mixed,
       matchUpType: DOUBLES_MATCHUP,
       gender: GenderEnum.Mixed,
+      referenceEvent,
     },
     expectation: { valid: true },
   },
@@ -163,6 +170,7 @@ const scenarios = [
       referenceGender: GenderEnum.Mixed,
       matchUpType: DOUBLES_MATCHUP,
       gender: GenderEnum.Female,
+      referenceEvent,
     },
     expectation: { valid: true },
   },
@@ -171,6 +179,7 @@ const scenarios = [
       referenceGender: GenderEnum.Mixed,
       matchUpType: SINGLES_MATCHUP,
       gender: GenderEnum.Female,
+      referenceEvent,
     },
     expectation: { valid: true },
   },
@@ -179,6 +188,7 @@ const scenarios = [
       referenceGender: GenderEnum.Mixed,
       matchUpType: SINGLES_MATCHUP,
       gender: GenderEnum.Male,
+      referenceEvent,
     },
     expectation: { valid: true },
   },
@@ -187,6 +197,7 @@ const scenarios = [
       referenceGender: GenderEnum.Mixed,
       matchUpType: DOUBLES_MATCHUP,
       gender: GenderEnum.Male,
+      referenceEvent,
     },
     expectation: { valid: true },
   },
@@ -197,9 +208,9 @@ const scenarios = [
       gender: GenderEnum.Any,
     },
     expectation: {
+      stack: ['tieFormatGenderValidityCheck'],
+      info: mixedGenderError,
       error: INVALID_GENDER,
-      stack: ['genderValidityCheck'],
-      info: 'MIXED events can not contain mixed singles or coed collections',
       valid: false,
     },
   },
@@ -210,15 +221,15 @@ const scenarios = [
       gender: GenderEnum.Any,
     },
     expectation: {
+      stack: ['tieFormatGenderValidityCheck'],
+      info: mixedGenderError,
       error: INVALID_GENDER,
-      stack: ['genderValidityCheck'],
-      info: 'MIXED events can not contain mixed singles or coed collections',
       valid: false,
     },
   },
 ];
 
 it.each(scenarios)('can test gender validity', (scenario) => {
-  const result = genderValidityCheck(scenario.params);
+  const result = tieFormatGenderValidityCheck(scenario.params);
   expect(result).toEqual(scenario.expectation);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { getAssignedParticipantIds } from './drawEngine/getters/getAssignedParti
 import { findExtension } from './tournamentEngine/governors/queryGovernor/extensionQueries';
 import { participantScaleItem } from './tournamentEngine/accessors/participantScaleItem';
 import { getScaleValues } from './tournamentEngine/getters/participants/getScaleValues';
-import { genderValidityCheck } from './global/functions/deducers/genderValidityCheck';
+import { tieFormatGenderValidityCheck } from './global/functions/deducers/tieFormatGenderValidityCheck';
 import { scoreHasValue } from './matchUpEngine/governors/queryGovernor/scoreHasValue';
 import { garman } from './competitionEngine/governors/scheduleGovernor/garman/garman';
 import { generateScoreString } from './matchUpEngine/generators/generateScoreString';
@@ -93,7 +93,7 @@ export const utilities = {
   findExtension,
   flattenJSON,
   garman,
-  genderValidityCheck,
+  tieFormatGenderValidityCheck,
   generateHashCode,
   generateRange,
   generateScoreString,

--- a/src/matchUpEngine/governors/tieFormatGovernor/tieFormatUtilities.ts
+++ b/src/matchUpEngine/governors/tieFormatGovernor/tieFormatUtilities.ts
@@ -1,4 +1,4 @@
-import { genderValidityCheck } from '../../../global/functions/deducers/genderValidityCheck';
+import { tieFormatGenderValidityCheck } from '../../../global/functions/deducers/tieFormatGenderValidityCheck';
 import { categoryCanContain } from '../../../global/functions/deducers/categoryCanContain';
 import { mustBeAnArray } from '../../../utilities/mustBeAnArray';
 import { isConvertableInteger } from '../../../utilities/math';
@@ -234,7 +234,8 @@ export function validateCollectionDefinition({
   }
 
   if (checkGender) {
-    const result = genderValidityCheck({
+    const result = tieFormatGenderValidityCheck({
+      referenceEvent: event,
       referenceGender,
       matchUpType,
       gender,


### PR DESCRIPTION
Updated logic for collections gender validation based on new USTA requirements. These are acceptable collection definitions for mixed and coed team events:

1. Mixed team events:
- Male Singles
- Female Singles
- Male Doubles
- Female Doubles
- Mixed Doubles

2. Coed team events:
- Male Singles
- Female Singles
- Male Doubles
- Female Doubles
- Mixed Doubles
- Coed Singles
- Coed Doubles