### PR TITLE
fix: export hydrated type declarations and set file for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
       "default": "./dist/index.js"
     }
   },
+  "types": "dist/tods-competition-factory.d.ts",
   "typesVersions": {
     "*": {
       "query": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,4 +35,4 @@ export * as factoryConstants from './constants';
 export * from './constants';
 
 // TYPES -----------------------------------------------------------------
-export type * as types from './types';
+export type * from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,3 +33,6 @@ export { fixtures } from './fixtures';
 // CONSTANTS -------------------------------------------------------------
 export * as factoryConstants from './constants';
 export * from './constants';
+
+// TYPES -----------------------------------------------------------------
+export type * as types from './types';

--- a/src/types/hydrated.ts
+++ b/src/types/hydrated.ts
@@ -8,13 +8,6 @@ export type HydratedVenue = {
   [key: string]: any;
 } & Venue;
 
-/*
-export type HydratedMatchUp = MatchUp & {
-  [key: string | number]: any;
-  sides?: HydratedSide[];
-};
-*/
-
 export interface HydratedMatchUp extends MatchUp {
   [key: string | number]: any;
   sides?: HydratedSide[];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,3 @@
+export * from './factoryTypes';
+export * from './hydrated';
+export * from './tournamentTypes';


### PR DESCRIPTION
Adding an index.ts file for exporting all the custom types set up - especially the hydrated types.

Sets the `types` field on package.json so we can easily browse what types are available.

This should make it easier to import, e.g.

```
import type { HydratedMatchUp } from 'tods-competition-factory';
const matchup: HydratedMatchUp = {
  matchUpId: '1234-abcd',
};
```