### PR TITLE
fix: ignore tieMatchUps when determining qualifiers from qualifying draw

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "ajv-formats": "3.0.1",
     "body-parser": "1.20.3",
     "c8": "10.1.3",
-    "chalk": "5.3.0",
+    "chalk": "5.4.0",
     "esbuild": "0.24.0",
     "eslint": "8.57.1",
     "eslint-config-prettier": "9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,8 +129,8 @@ importers:
         specifier: 10.1.3
         version: 10.1.3
       chalk:
-        specifier: 5.3.0
-        version: 5.3.0
+        specifier: 5.4.0
+        version: 5.4.0
       esbuild:
         specifier: 0.24.0
         version: 0.24.0
@@ -2604,6 +2604,10 @@ packages:
 
   chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chalk@5.4.0:
+    resolution: {integrity: sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   char-regex@1.0.2:
@@ -6626,7 +6630,7 @@ snapshots:
   '@commitlint/format@19.5.0':
     dependencies:
       '@commitlint/types': 19.5.0
-      chalk: 5.3.0
+      chalk: 5.4.0
 
   '@commitlint/is-ignored@19.6.0':
     dependencies:
@@ -6646,7 +6650,7 @@ snapshots:
       '@commitlint/execute-rule': 19.5.0
       '@commitlint/resolve-extends': 19.5.0
       '@commitlint/types': 19.5.0
-      chalk: 5.3.0
+      chalk: 5.4.0
       cosmiconfig: 9.0.0(typescript@5.7.2)
       cosmiconfig-typescript-loader: 6.1.0(@types/node@22.10.2)(cosmiconfig@9.0.0(typescript@5.7.2))(typescript@5.7.2)
       lodash.isplainobject: 4.0.6
@@ -6697,7 +6701,7 @@ snapshots:
   '@commitlint/types@19.5.0':
     dependencies:
       '@types/conventional-commits-parser': 5.0.0
-      chalk: 5.3.0
+      chalk: 5.4.0
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -8377,6 +8381,8 @@ snapshots:
 
   chalk@5.3.0: {}
 
+  chalk@5.4.0: {}
+
   char-regex@1.0.2: {}
 
   chardet@0.7.0: {}
@@ -9554,7 +9560,7 @@ snapshots:
     dependencies:
       '@ljharb/through': 2.3.13
       ansi-escapes: 4.3.2
-      chalk: 5.3.0
+      chalk: 5.4.0
       cli-cursor: 3.1.0
       cli-width: 4.1.0
       external-editor: 3.1.0

--- a/src/mutate/drawDefinitions/positionGovernor/qualifierProgression.ts
+++ b/src/mutate/drawDefinitions/positionGovernor/qualifierProgression.ts
@@ -94,8 +94,8 @@ export function qualifierProgression({
       const { matchUps } = getAllStructureMatchUps({
         matchUpFilters: {
           ...(qualifyingRoundNumber && { roundNumbers: [qualifyingRoundNumber] }),
-          hasWinningSide: true,
           isCollectionMatchUp: false,
+          hasWinningSide: true,
         },
         afterRecoveryTimes: false,
         inContext: true,

--- a/src/mutate/drawDefinitions/positionGovernor/qualifierProgression.ts
+++ b/src/mutate/drawDefinitions/positionGovernor/qualifierProgression.ts
@@ -95,6 +95,7 @@ export function qualifierProgression({
         matchUpFilters: {
           ...(qualifyingRoundNumber && { roundNumbers: [qualifyingRoundNumber] }),
           hasWinningSide: true,
+          isCollectionMatchUp: false,
         },
         afterRecoveryTimes: false,
         inContext: true,

--- a/src/query/drawDefinition/positionActions/getValidQualifiersAction.ts
+++ b/src/query/drawDefinition/positionActions/getValidQualifiersAction.ts
@@ -77,8 +77,8 @@ export function getValidQualifiersAction({
       const { matchUps } = getAllStructureMatchUps({
         matchUpFilters: {
           roundNumbers: [qualifyingRoundNumber],
-          hasWinningSide: true,
           isCollectionMatchUp: false,
+          hasWinningSide: true,
         },
         afterRecoveryTimes: false,
         tournamentParticipants,

--- a/src/query/drawDefinition/positionActions/getValidQualifiersAction.ts
+++ b/src/query/drawDefinition/positionActions/getValidQualifiersAction.ts
@@ -78,6 +78,7 @@ export function getValidQualifiersAction({
         matchUpFilters: {
           roundNumbers: [qualifyingRoundNumber],
           hasWinningSide: true,
+          isCollectionMatchUp: false,
         },
         afterRecoveryTimes: false,
         tournamentParticipants,


### PR DESCRIPTION
For team events `qualifierProgression` and `getValidQualifiersAction` both consider winning individual participants from `tieMatchUps` to be qualifying participants if the team qualifies.

This PR filters the considered matchUps to ignore collection matchUps.

**Returned qualifiers before fix:**

![image](https://github.com/user-attachments/assets/60116ac4-36e6-46d6-b245-f3c7ffe237f7)


**Returned qualifiers after fix:**

![image](https://github.com/user-attachments/assets/f1eedcc0-da0c-408b-ba93-7654e336a5ee)

