### PR TITLE
Limit clear score and manage double wo propagation

### DIFF
--- a/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
+++ b/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
@@ -31,6 +31,8 @@ export function doubleExitAdvancement(params) {
     [WALKOVER, DEFAULTED].includes(loserMatchUp?.matchUpStatus) &&
     !loserMatchUp.sides?.map((side) => side.participantId ?? side.participant).filter(Boolean).length;
 
+  const loserMatchUpIsDoubleExit = loserMatchUp?.matchUpStatus === DOUBLE_WALKOVER;
+
   if (loserMatchUp && loserMatchUp.matchUpStatus !== BYE) {
     const { loserTargetLink } = targetLinks;
     if (
@@ -49,10 +51,11 @@ export function doubleExitAdvancement(params) {
         event,
       });
       if (result.error) return decorateResult({ result, stack });
-    } else if (!loserMatchUpIsEmptyExit) {
+    } else if (!loserMatchUpIsDoubleExit) {
       // only attemp to advance the loserMatchUp if it is not an 'empty' exit present
       const { feedRound, drawPositions, matchUpId } = loserMatchUp;
-      const walkoverWinningSide = feedRound ? 2 : 2 - drawPositions.indexOf(loserTargetDrawPosition);
+      let walkoverWinningSide: number | undefined = feedRound ? 2 : 2 - drawPositions.indexOf(loserTargetDrawPosition);
+      walkoverWinningSide = loserMatchUpIsEmptyExit ? loserMatchUp.winningSide : walkoverWinningSide;
       const result = conditionallyAdvanceDrawPosition({
         ...params,
         targetMatchUp: loserMatchUp,
@@ -62,9 +65,8 @@ export function doubleExitAdvancement(params) {
         matchUpId,
       });
       if (result.error) return decorateResult({ result, stack });
-    }
+    } 
   }
-
   if (winnerMatchUp) {
     const result = conditionallyAdvanceDrawPosition({
       ...params,
@@ -78,6 +80,7 @@ export function doubleExitAdvancement(params) {
 
   return decorateResult({ result: { ...SUCCESS }, stack });
 }
+
 
 // 1. Assigns a WALKOVER or DEFAULTED status to the winnerMatchUp
 // 2. Advances any drawPosition that is already present
@@ -360,7 +363,15 @@ function conditionallyAdvanceDrawPosition(params) {
 }
 
 function advanceByeToLoserMatchUp(params) {
-  const { loserTargetDrawPosition, tournamentRecord, loserTargetLink, drawDefinition, matchUpsMap, event } = params;
+  const {
+    loserTargetDrawPosition,
+    tournamentRecord,
+    loserTargetLink,
+    drawDefinition,
+    matchUpsMap,
+    event,
+    loserMatchUp,
+  } = params;
   const structureId = loserTargetLink?.target?.structureId;
   const { structure } = findStructure({ drawDefinition, structureId });
   if (!structure) return { error: MISSING_STRUCTURE };
@@ -371,6 +382,7 @@ function advanceByeToLoserMatchUp(params) {
     drawDefinition,
     structureId,
     matchUpsMap,
+    loserMatchUp,
     event,
   });
 }

--- a/src/mutate/matchUps/drawPositions/assignDrawPositionBye.ts
+++ b/src/mutate/matchUps/drawPositions/assignDrawPositionBye.ts
@@ -16,7 +16,7 @@ import { numericSort } from '@Tools/sorting';
 
 // constants and types
 import { DrawDefinition, Event, MatchUp, Structure, Tournament } from '@Types/tournamentTypes';
-import { BYE, TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
+import { BYE, TO_BE_PLAYED, DEFAULTED, WALKOVER } from '@Constants/matchUpStatusConstants';
 import { CONTAINER } from '@Constants/drawDefinitionConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import { HydratedMatchUp } from '@Types/hydrated';
@@ -70,6 +70,7 @@ type AssignDrawPositionByeArgs = {
   structure?: Structure;
   drawPosition: number;
   structureId?: string;
+  loserMatchUp?: MatchUp;
   event?: Event;
 };
 
@@ -79,6 +80,7 @@ export function assignDrawPositionBye({
   tournamentRecord,
   drawDefinition,
   drawPosition,
+  loserMatchUp,
   matchUpsMap,
   structureId,
   structure,
@@ -108,9 +110,13 @@ export function assignDrawPositionBye({
     return { ...SUCCESS };
   }
 
+  //
+  const hasPropagatedStatus = !!(loserMatchUp && matchUpsMap.drawMatchUps.find(
+    (m) => m.loserMatchUpId === loserMatchUp?.matchUpId && [DEFAULTED, WALKOVER].includes(m.matchUpStatus),
+  ));
   // ################### Check error conditions ######################
   const drawPositionIsActive = activeDrawPositions?.includes(drawPosition);
-  if (drawPositionIsActive) {
+  if (drawPositionIsActive && !hasPropagatedStatus) {
     return { error: DRAW_POSITION_ACTIVE };
   }
 
@@ -120,7 +126,7 @@ export function assignDrawPositionBye({
   const { filled, containsBye, assignedParticipantId } = drawPositionFilled(positionAssignment);
   if (containsBye) return { ...SUCCESS }; // nothing to be done
 
-  if (filled && !containsBye) {
+  if (filled && !containsBye && !hasPropagatedStatus) {
     return decorateResult({ result: { error: DRAW_POSITION_ASSIGNED }, stack });
   }
 
@@ -153,6 +159,11 @@ export function assignDrawPositionBye({
   positionAssignments?.forEach((assignment) => {
     if (assignment.drawPosition === drawPosition) {
       assignment.bye = true;
+      //let's clear up the participant from the assignment
+      //if it was there because of a propagated exit.
+      if (hasPropagatedStatus) {
+        assignment.participantId = undefined
+      }
     }
   });
 

--- a/src/mutate/matchUps/drawPositions/removeDirectedParticipants.ts
+++ b/src/mutate/matchUps/drawPositions/removeDirectedParticipants.ts
@@ -16,7 +16,7 @@ import { instanceCount } from '@Tools/arrays';
 import { ErrorType, MISSING_DRAW_POSITIONS, STRUCTURE_NOT_FOUND } from '@Constants/errorConditionConstants';
 import { DrawDefinition, DrawLink, Event, Tournament } from '@Types/tournamentTypes';
 import { FIRST_MATCHUP } from '@Constants/drawDefinitionConstants';
-import { TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
+import { DOUBLE_WALKOVER, TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import { HydratedMatchUp } from '@Types/hydrated';
 import { MatchUpsMap } from '@Types/factoryTypes';
@@ -310,8 +310,16 @@ function removeDirectedLoser({
   });
 
   if (sourceMatchUpId && sourceMatchUpStatus) {
-    // TODO: update matchUpStatusCodes if necessary
-    // console.log({ sourceMatchUpId, sourceMatchUpStatus });
+    //It could be that the loser match up was already a double walkover with one propagated
+    //exit with a player and the other participant as a produced exit from a parent double WO.
+    //We then want to remove the specific WO reason for the participant as the participant
+    //has been removed from the draw positions and this is now a straight double WO.
+    //In case the loser matchup was not a double WO we jsut remove the status codes.
+    //
+    //TODO: figure out what happens for non Dobule WO loser matchups. Does it reset status codes that should
+    //instead been kept? not sure how to test this.
+    const targetMatchUp = matchUpsMap?.drawMatchUps?.find(({ matchUpId }) => matchUpId === loserMatchUp.matchUpId);
+    targetMatchUp.matchUpStatusCodes = sourceMatchUpStatus === DOUBLE_WALKOVER ? ['WO', 'WO'] : [];
   }
 
   // remove participant from seedAssignments

--- a/src/query/drawDefinition/isActiveDownstream.ts
+++ b/src/query/drawDefinition/isActiveDownstream.ts
@@ -1,12 +1,13 @@
 import { positionTargets } from '@Query/matchUp/positionTargets';
 
 // constants
-import { BYE, DEFAULTED, WALKOVER } from '@Constants/matchUpStatusConstants';
+import { BYE, DEFAULTED, DOUBLE_WALKOVER, TO_BE_PLAYED, WALKOVER } from '@Constants/matchUpStatusConstants';
 import { FIRST_MATCHUP } from '@Constants/drawDefinitionConstants';
+import { WITHDRAWN } from '../../constants/entryStatusConstants';
 
 export function isActiveDownstream(params) {
   // relevantLink is passed in iterative calls (see below)
-  const { inContextDrawMatchUps, targetData, drawDefinition, relevantLink } = params;
+  const { inContextDrawMatchUps, targetData, drawDefinition, relevantLink, matchUpStatus, score, winningSide, matchUpsMap } = params;
 
   const fmlcBYE = relevantLink?.linkCondition === FIRST_MATCHUP && targetData?.matchUp?.matchUpStatus === BYE;
   if (fmlcBYE) return false;
@@ -26,11 +27,29 @@ export function isActiveDownstream(params) {
 
   // NOTE: produced WALKOVER, DEFAULTEED fed into consolation structures should NOT be considered active
   // IF: the loserMatchUp has no further downstream matchUps or there is no propagated loserParticipant (e.g. DOUBLE_EXIT)
-
   const loserExitPropagation = loserTargetData?.targetMatchUps?.loserMatchUp;
   const loserIndex = loserTargetData?.targetMatchUps?.loserMatchUpDrawPositionIndex;
   const propagatedLoserParticipant = loserExitPropagation?.sides[loserIndex]?.participant;
   const loserMatchUpExit = [DEFAULTED, WALKOVER].includes(loserMatchUp?.matchUpStatus) && !propagatedLoserParticipant;
+  
+
+  
+  const isLoserMatchUpWO = [DEFAULTED, WALKOVER].includes(loserMatchUp?.matchUpStatus);
+  const hasLoserMatchUpUpstreamWOMatches = !!matchUpsMap?.drawMatchUps.find(
+    (m) => m.loserMatchUpId === loserMatchUp?.matchUpId && [DEFAULTED, WALKOVER, WITHDRAWN].includes(m.matchUpStatus),
+  ); 
+  //to identify a propagated exit (WO/DEFAULT) for matches that are WO/DEFAULT, have a winning side,
+  //and have only one participant (the WO/DF player).
+  const loserMatchUpParticipantsCount =
+    loserMatchUp?.sides?.reduce((acc, current) => (current?.participant ? ++acc : acc), 0) ?? 0;
+  const isLoserMatchUpWalkoverWithOnePlayer =
+    //this catches downstream matches marked as WO with only one participant
+    loserMatchUp?.winningSide && isLoserMatchUpWO && loserMatchUpParticipantsCount === 1;
+
+  //we want to figure out if the command is for clearing the score as this
+  //can have downstream effects.
+  const isClearScore =
+    matchUpStatus === TO_BE_PLAYED && score?.scoreStringSide1 === '' && score?.scoreStringSide2 === '' && !winningSide;
 
   const winnerDrawPositionsCount = winnerMatchUp?.drawPositions?.filter(Boolean).length || 0;
 
@@ -38,7 +57,17 @@ export function isActiveDownstream(params) {
   // unless one of its downstream matchUps is active
 
   if (
-    (loserMatchUp?.winningSide && !loserMatchUpExit) ||
+    //if there is a downstream match with two propagated exits we mark it as active
+    (hasLoserMatchUpUpstreamWOMatches && loserMatchUp?.matchUpStatus === DOUBLE_WALKOVER && isClearScore) ||
+    //if there is a downstream propagated exit and we are trying to clear the score we stop the user
+    //by marking the downstream as active
+    (hasLoserMatchUpUpstreamWOMatches && isLoserMatchUpWO && isClearScore) ||
+    //if the downstream has not a propagated exit we run the existing checks,
+    //otherwise we let them set the score. This is to counter act the fact
+    //that propagated exit status matches can be marked as WALKOVER with only one
+    //participant. This would have been marked as an active downstream before.
+    (!isLoserMatchUpWalkoverWithOnePlayer &&
+      ((loserMatchUp?.winningSide && !loserMatchUpExit) ||
     (winnerMatchUp?.winningSide &&
       winnerDrawPositionsCount === 2 &&
       (!winnerMatchUp.feedRound || ![WALKOVER, DEFAULTED].includes(winnerMatchUp?.matchUpStatus)))

--- a/src/tests/mutations/matchUps/matchUpStatus/isActiveDownstream.test.ts
+++ b/src/tests/mutations/matchUps/matchUpStatus/isActiveDownstream.test.ts
@@ -3,9 +3,9 @@ import mocksEngine from '@Assemblies/engines/mock';
 import { it, expect } from 'vitest';
 
 // Constants
-import { CANNOT_CHANGE_WINNING_SIDE } from '@Constants/errorConditionConstants';
-import { WALKOVER } from '@Constants/matchUpStatusConstants';
-import { COMPASS } from '@Constants/drawDefinitionConstants';
+import { CANNOT_CHANGE_WINNING_SIDE, INCOMPATIBLE_MATCHUP_STATUS } from '@Constants/errorConditionConstants';
+import { BYE, COMPLETED, DOUBLE_WALKOVER, TO_BE_PLAYED, WALKOVER } from '@Constants/matchUpStatusConstants';
+import { COMPASS, FIRST_MATCH_LOSER_CONSOLATION } from '@Constants/drawDefinitionConstants';
 
 it('will not allow winningSide change when active downstream', () => {
   mocksEngine.generateTournamentRecord({
@@ -92,4 +92,243 @@ it('will not allow winningSide change when active downstream', () => {
   const walkoverPropagatedParticipant = southFinal.sides[0].participant;
 
   expect(initialWoPropagatedParticipant.participantId).not.toEqual(walkoverPropagatedParticipant.participantId);
+});
+
+it('Does mark a downstream as active if we are trying to reset the score for one of the source matches of a propagated exit status consolation match with both players set', () => {
+  const idPrefix = 'matchUp';
+  const drawId = 'drawId';
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [
+      // uuids are popped and therefore assigned in reverse order
+      // in this instance the uuids are assigned to structureIds in the order they are generated
+      { drawId, drawSize: 32, drawType: COMPASS, idPrefix, uuids: ['a8', 'a7', 'a6', 'a5', 'a4', 'a3', 'a2', 'a1'] },
+    ],
+    setState: true,
+  });
+
+  //let's set the first match in EAST as a WALKOVER
+  //and we propgate the exit status
+  let matchUpId = 'matchUp-East-RP-1-1';
+  let result = tournamentEngine.setMatchUpStatus({
+    outcome: { matchUpStatus: WALKOVER, winningSide: 2 },
+    propagateExitStatus: true,
+    matchUpId,
+    drawId,
+  });
+  expect(result.success).toEqual(true);
+  //let's set the second match in EAST as a normal score
+  matchUpId = 'matchUp-East-RP-1-2';
+  result = tournamentEngine.setMatchUpStatus({
+    outcome: { winningSide: 2, scoreStringSide1: '11-3', scoreStringSide2: '3-11' },
+    propagateExitStatus: false,
+    matchUpId,
+    drawId,
+  });
+  expect(result.success).toEqual(true);
+
+  //the first Match in WEST should be a WALKOVER with a winner
+
+  let matchUps = tournamentEngine.allDrawMatchUps({ drawId }).matchUps;
+  let matchUp = matchUps?.find((matchUp) => matchUp.matchUpId === matchUpId);
+  expect(matchUp?.matchUpStatus).toEqual(COMPLETED);
+  let westLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === matchUp?.loserMatchUpId);
+  expect(westLoserMatchUp?.matchUpStatus).toEqual(WALKOVER);
+  let southLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === westLoserMatchUp?.loserMatchUpId);
+  expect(southLoserMatchUp?.matchUpStatus).toEqual(WALKOVER);
+  let southEastLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === southLoserMatchUp?.loserMatchUpId);
+  expect(southEastLoserMatchUp?.matchUpStatus).toEqual(WALKOVER);
+
+  //trying to clear the score on any of the first two matches in EAST should fail
+  //because they will have an active downstream
+  matchUpId = 'matchUp-East-RP-1-1';
+  result = tournamentEngine.setMatchUpStatus({
+    outcome: { scoreStringSide1: '', scoreStringSide2: '', matchUpStatus: TO_BE_PLAYED },
+    propagateExitStatus: false,
+    matchUpId,
+    drawId,
+  });
+  expect(result.error).toEqual(INCOMPATIBLE_MATCHUP_STATUS);
+  matchUpId = 'matchUp-East-RP-1-2';
+  result = tournamentEngine.setMatchUpStatus({
+    outcome: { score: { scoreStringSide1: '', scoreStringSide2: '' }, matchUpStatus: TO_BE_PLAYED },
+    propagateExitStatus: false,
+    matchUpId,
+    drawId,
+  });
+  expect(result.error).toEqual(INCOMPATIBLE_MATCHUP_STATUS);
+
+  //and make sure that the existing matches have not been changed
+  matchUps = tournamentEngine.allDrawMatchUps({ drawId }).matchUps;
+  matchUp = matchUps?.find((matchUp) => matchUp.matchUpId === matchUpId);
+  expect(matchUp?.matchUpStatus).toEqual(COMPLETED);
+  westLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === matchUp?.loserMatchUpId);
+  expect(westLoserMatchUp?.matchUpStatus).toEqual(WALKOVER);
+  southLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === westLoserMatchUp?.loserMatchUpId);
+  expect(southLoserMatchUp?.matchUpStatus).toEqual(WALKOVER);
+  southEastLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === southLoserMatchUp?.loserMatchUpId);
+  expect(southEastLoserMatchUp?.matchUpStatus).toEqual(WALKOVER);
+});
+
+it('Does mark downstream as active if we are trying to reset the score for one of the source matches of a propagated exit status consolation match with only one player', () => {
+  const idPrefix = 'matchUp';
+  const drawId = 'drawId';
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [
+      // uuids are popped and therefore assigned in reverse order
+      // in this instance the uuids are assigned to structureIds in the order they are generated
+      { drawId, drawSize: 32, drawType: FIRST_MATCH_LOSER_CONSOLATION, idPrefix },
+    ],
+    setState: true,
+  });
+
+  //let's set the first match in MAIN as a WALKOVER
+  //and we propgate the exit status
+  let matchUpId = 'matchUp-1-1';
+  let result = tournamentEngine.setMatchUpStatus({
+    outcome: { matchUpStatus: WALKOVER, winningSide: 2 },
+    propagateExitStatus: true,
+    matchUpId,
+    drawId,
+  });
+  expect(result.success).toEqual(true);
+
+  //the first Match in CONSOLATION should be a WALKOVER with a winner
+  let matchUps = tournamentEngine.allDrawMatchUps({ drawId }).matchUps;
+  let matchUp = matchUps?.find((matchUp) => matchUp.matchUpId === matchUpId);
+  expect(matchUp?.matchUpStatus).toEqual(WALKOVER);
+  let loserMatchUp = matchUps?.find((mU) => mU.matchUpId === matchUp?.loserMatchUpId);
+  expect(loserMatchUp?.matchUpStatus).toEqual(WALKOVER);
+
+  //trying to clear the score on any of the first two matches in MAIN should fail
+  //because they will have an active downstream
+  matchUpId = 'matchUp-1-1';
+  result = tournamentEngine.setMatchUpStatus({
+    outcome: { score: { scoreStringSide1: '', scoreStringSide2: '' }, matchUpStatus: TO_BE_PLAYED },
+    propagateExitStatus: false,
+    matchUpId,
+    drawId,
+  });
+  expect(result.error).toEqual(INCOMPATIBLE_MATCHUP_STATUS);
+
+  //and make sure that the existing matches have not been changed
+  matchUps = tournamentEngine.allDrawMatchUps({ drawId }).matchUps;
+  matchUp = matchUps?.find((matchUp) => matchUp.matchUpId === matchUpId);
+  expect(matchUp?.matchUpStatus).toEqual(WALKOVER);
+  loserMatchUp = matchUps?.find((mU) => mU.matchUpId === matchUp?.loserMatchUpId);
+  expect(loserMatchUp?.matchUpStatus).toEqual(WALKOVER);
+});
+
+it('Does mark downstream as active if we are trying to reset the score for one of the source matches of a propagated exit status consolation match with only one player', () => {
+  const idPrefix = 'matchUp';
+  const drawId = 'drawId';
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [
+      // uuids are popped and therefore assigned in reverse order
+      // in this instance the uuids are assigned to structureIds in the order they are generated
+      { drawId, drawSize: 32, drawType: COMPASS, idPrefix, uuids: ['a8', 'a7', 'a6', 'a5', 'a4', 'a3', 'a2', 'a1'] },
+    ],
+    setState: true,
+  });
+
+  //let's set the first match in EAST as a WALKOVER
+  //and we propgate the exit status
+  let matchUpId = 'matchUp-East-RP-1-1';
+  let result = tournamentEngine.setMatchUpStatus({
+    outcome: { matchUpStatus: WALKOVER, winningSide: 2 },
+    propagateExitStatus: true,
+    matchUpId,
+    drawId,
+  });
+  expect(result.success).toEqual(true);
+
+  //the first Match in WEST should be a WALKOVER with a winner
+
+  let matchUps = tournamentEngine.allDrawMatchUps({ drawId }).matchUps;
+  let matchUp = matchUps?.find((matchUp) => matchUp.matchUpId === matchUpId);
+  expect(matchUp?.matchUpStatus).toEqual(WALKOVER);
+  let westLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === matchUp?.loserMatchUpId);
+  expect(westLoserMatchUp?.matchUpStatus).toEqual(WALKOVER);
+  let southLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === westLoserMatchUp?.loserMatchUpId);
+  expect(southLoserMatchUp?.matchUpStatus).toEqual(WALKOVER);
+  let southEastLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === southLoserMatchUp?.loserMatchUpId);
+  expect(southEastLoserMatchUp?.matchUpStatus).toEqual(WALKOVER);
+
+  //trying to clear the score on any of the first two matches in EAST should fail
+  //because they will have an active downstream
+  matchUpId = 'matchUp-East-RP-1-1';
+  result = tournamentEngine.setMatchUpStatus({
+    outcome: { score: { scoreStringSide1: '', scoreStringSide2: '' }, matchUpStatus: TO_BE_PLAYED },
+    propagateExitStatus: false,
+    matchUpId,
+    drawId,
+  });
+  expect(result.error).toEqual(INCOMPATIBLE_MATCHUP_STATUS);
+
+  //and make sure that the existing matches have not been changed
+  matchUps = tournamentEngine.allDrawMatchUps({ drawId }).matchUps;
+  matchUp = matchUps?.find((matchUp) => matchUp.matchUpId === matchUpId);
+  expect(matchUp?.matchUpStatus).toEqual(WALKOVER);
+  westLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === matchUp?.loserMatchUpId);
+  expect(westLoserMatchUp?.matchUpStatus).toEqual(WALKOVER);
+  southLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === westLoserMatchUp?.loserMatchUpId);
+  expect(southLoserMatchUp?.matchUpStatus).toEqual(WALKOVER);
+  southEastLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === southLoserMatchUp?.loserMatchUpId);
+  expect(southEastLoserMatchUp?.matchUpStatus).toEqual(WALKOVER);
+});
+
+it('Does NOT mark downstream as active if the consolation match has the result of a double walkover and allows to clear score in source match', () => {
+  const idPrefix = 'matchUp';
+  const drawId = 'drawId';
+  mocksEngine.generateTournamentRecord({
+    drawProfiles: [
+      // uuids are popped and therefore assigned in reverse order
+      // in this instance the uuids are assigned to structureIds in the order they are generated
+      { drawId, drawSize: 32, drawType: COMPASS, idPrefix, uuids: ['a8', 'a7', 'a6', 'a5', 'a4', 'a3', 'a2', 'a1'] },
+    ],
+    setState: true,
+  });
+
+  //let's set the first match in EAST as a WALKOVER
+  //and we propgate the exit status
+  let matchUpId = 'matchUp-East-RP-1-1';
+  let result = tournamentEngine.setMatchUpStatus({
+    outcome: { matchUpStatus: DOUBLE_WALKOVER },
+    propagateExitStatus: false,
+    matchUpId,
+    drawId,
+  });
+  expect(result.success).toEqual(true);
+
+  //the first Match in WEST should be WALKOVER with a winner
+  //but no participants
+  let matchUps = tournamentEngine.allDrawMatchUps({ drawId }).matchUps;
+  let matchUp = matchUps?.find((matchUp) => matchUp.matchUpId === matchUpId);
+  expect(matchUp?.matchUpStatus).toEqual(DOUBLE_WALKOVER);
+  let westLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === matchUp?.loserMatchUpId);
+  expect(westLoserMatchUp?.matchUpStatus).toEqual(WALKOVER);
+  let southLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === westLoserMatchUp?.loserMatchUpId);
+  expect(southLoserMatchUp?.matchUpStatus).toEqual(BYE);
+  let southEastLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === southLoserMatchUp?.loserMatchUpId);
+  expect(southEastLoserMatchUp?.matchUpStatus).toEqual(BYE);
+
+  //trying to clear the score on any of the first two matches in EAST should work
+  //because they will have no active downstream
+  matchUpId = 'matchUp-East-RP-1-1';
+  result = tournamentEngine.setMatchUpStatus({
+    outcome: { scoreStringSide1: '', scoreStringSide2: '', matchUpStatus: TO_BE_PLAYED },
+    propagateExitStatus: false,
+    matchUpId,
+    drawId,
+  });
+  expect(result.success).toEqual(true);
+
+  matchUps = tournamentEngine.allDrawMatchUps({ drawId }).matchUps;
+  matchUp = matchUps?.find((matchUp) => matchUp.matchUpId === matchUpId);
+  expect(matchUp?.matchUpStatus).toEqual(TO_BE_PLAYED);
+  westLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === matchUp?.loserMatchUpId);
+  expect(westLoserMatchUp?.matchUpStatus).toEqual(TO_BE_PLAYED);
+  southLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === westLoserMatchUp?.loserMatchUpId);
+  expect(southLoserMatchUp?.matchUpStatus).toEqual(TO_BE_PLAYED);
+  southEastLoserMatchUp = matchUps?.find((mU) => mU.matchUpId === southLoserMatchUp?.loserMatchUpId);
+  expect(southEastLoserMatchUp?.matchUpStatus).toEqual(TO_BE_PLAYED);
 });


### PR DESCRIPTION
this is the work to stop the clearing of scores if there is a propagated status in the downstream. I also manages the propagation of double WO caused by single propagated WO in the upstream matches.

This was rebased on the latest dev branch and I have noticed that we have lost the `propagateStatus.test` file. We need to recover it from old commits.

