### PR TITLE
chore: add release please to manage publishing of new versions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,45 @@
+name: release-please
+
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+    release-please:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Release Please
+              id: release
+              uses: google-github-actions/release-please-action@v4
+              with:
+                  release-type: node
+
+            - name: Checkout repository
+              if: steps.release.outputs.release_created == 'true'
+              uses: actions/checkout@v4
+
+            - name: Set up Node.js
+              if: steps.release.outputs.release_created == 'true'
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+                  registry-url: "https://registry.npmjs.org/"
+
+            - name: Install pnpm
+              if: steps.release.outputs.release_created == 'true'
+              uses: pnpm/action-setup@v3
+
+            - name: Install dependencies
+              if: steps.release.outputs.release_created == 'true'
+              run: pnpm install --frozen-lockfile
+
+            - name: Build package
+              if: steps.release.outputs.release_created == 'true'
+              run: pnpm run build
+
+            - name: Publish to npm
+              if: steps.release.outputs.release_created == 'true'
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+              run: pnpm publish --access public

--- a/package.json
+++ b/package.json
@@ -208,5 +208,6 @@
       "rollup",
       "unrs-resolver"
     ]
-  }
+  },
+  "packageManager": "pnpm@10.15.1"
 }


### PR DESCRIPTION
This adds release-please (https://github.com/googleapis/release-please) to manage the creation and publishing of new versions based on conventional commits.

When something is merged/pushed to master, release-please will look at the conventional commits and create a new PR with the bump in version (based on commits to figure out if it's a patch, minor, major change) and also update the CHANGELOG file. You then just merge that PR to commit the changes and publish the new version to npm.

A new secret needs to be set up (`NPM_TOKEN`) for the token to use to publish the npm.

One important thing mentioned on the release please documentation is that you should Rebase and Merge or Squash and Merge your PRs to master/dev, not just Merge. This is because release please works better with a linear history.

