### PR TITLE
ci: publish on release event (closes release-please → npm gap)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,9 +1,24 @@
 name: Publish to npm
 
+# Fires when a GitHub release is published. release-please creates
+# releases via GITHUB_TOKEN, and `release: published` is delivered
+# regardless of which token created it — unlike `push: tags`, which
+# GitHub silently drops when triggered by GITHUB_TOKEN to prevent
+# workflow loops. That gap is why v3.1.5 was tagged but never
+# auto-published.
+#
+# `workflow_dispatch` is kept for manual backfill — pass a `tag`
+# input (e.g. `v3.1.5`) to publish a tag that already exists.
+
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v3.1.5). Must already exist.'
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -12,7 +27,20 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Resolve tag
+        id: ref
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.ref.outputs.tag }}
 
       - uses: actions/setup-node@v6
         with:
@@ -31,10 +59,10 @@ jobs:
 
       - run: npm run test:server -- --forceExit
 
-      - name: Determine npm tag
-        id: tag
+      - name: Determine npm dist-tag
+        id: distTag
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          VERSION="${{ steps.ref.outputs.version }}"
           if [[ "$VERSION" == *"-alpha"* ]]; then
             echo "tag=alpha" >> "$GITHUB_OUTPUT"
           elif [[ "$VERSION" == *"-beta"* ]]; then
@@ -43,4 +71,4 @@ jobs:
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
-      - run: npm publish --provenance --access public --tag ${{ steps.tag.outputs.tag }}
+      - run: npm publish --provenance --access public --tag ${{ steps.distTag.outputs.tag }}

--- a/documentation/docs/governors/schedule-governor.md
+++ b/documentation/docs/governors/schedule-governor.md
@@ -253,12 +253,21 @@ engine.scheduleProfileRounds({
   scheduleDates, // optional - specific dates to schedule
   clearScheduleDates, // optional - boolean or array of dates to clear first
 
+  // Court selection
+  courtIds, // optional array - restrict scheduling to only these courts
+
   // Execution control
   dryRun, // optional boolean - preview without changes
   pro, // optional boolean - use grid scheduling instead of Garman
   checkPotentialRequestConflicts, // optional boolean (default: true)
 });
 ```
+
+**Court filtering with `courtIds`**:
+
+When `courtIds` is provided, the scheduler only considers those courts as available capacity. Useful when an operator wants auto-scheduling to operate against a subset of courts (e.g. when some courts are reserved for other purposes, or when scheduling is being applied per-court). Passing an empty array means "no courts are available" — the scheduler will run but place no matchUps. Omitting the parameter (the default) considers all enabled courts at the profile's venues.
+
+In `pro: true` mode, matchUps will receive `courtId` assignments only from the filtered set. In default (Garman) mode, the filter constrains capacity but final court assignment may still be deferred to play time.
 
 **Returns**:
 
@@ -335,6 +344,34 @@ SINGLES and DOUBLES matchUps are scheduled automatically. TEAM matchUps require 
 :::
 
 **See**: [Scheduling Profile](../concepts/scheduling-profile) and [Pro Scheduling](../concepts/pro-scheduling) for details.
+
+---
+
+### scheduleProfileGrid
+
+Profile-driven grid scheduling. Uses the scheduling profile to determine which rounds go on which dates at which venues, then places matchUps onto court grid positions (`courtOrder`) **without assigning times**. Used when an operator wants to manually assign times after the grid placement step.
+
+```js
+engine.scheduleProfileGrid({
+  scheduleDates, // optional - specific dates to schedule
+  clearScheduleDates, // optional - boolean or array of dates to clear first
+  scheduleCompletedMatchUps, // optional boolean - include completed matchUps
+  minCourtGridRows, // optional number - rows per court (default: 10)
+  courtIds, // optional array - restrict placement to only these courts
+});
+```
+
+When `courtIds` is provided, only courts in the set are considered as placement targets at each venue. Passing an empty array places nothing. Omitting the parameter places onto all courts at the profile's venues (the default).
+
+**Returns**:
+
+```js
+{
+  scheduledDates,         // array - dates where matchUps were placed
+  scheduledMatchUpIds,    // record<date, matchUpIds[]> - matchUps placed per date
+  notScheduledMatchUpIds, // record<date, matchUpIds[]> - matchUps that didn't fit per date
+}
+```
 
 ---
 
@@ -1108,26 +1145,27 @@ Adds multiple schedule attributes to a matchUp in a single call. This is the met
 
 ```js
 engine.addMatchUpScheduleItems({
-  matchUpId,                // required — target matchUp
-  drawId,                   // required — resolved to drawDefinition by engine
-  schedule: {               // required — schedule attributes to set
-    scheduledDate,          // optional — 'YYYY-MM-DD'
-    scheduledTime,          // optional — 'HH:mm' or ISO datetime
-    startTime,              // optional — actual start time
-    endTime,                // optional — actual end time
-    resumeTime,             // optional — resume after suspension
-    stopTime,               // optional — suspension time
-    courtId,                // optional — assigned court
-    venueId,                // optional — assigned venue
-    courtOrder,             // optional — order on court
-    homeParticipantId,      // optional — home team participant
-    courtIds,               // optional — for TEAM matchUps, allocate courts
+  matchUpId, // required — target matchUp
+  drawId, // required — resolved to drawDefinition by engine
+  schedule: {
+    // required — schedule attributes to set
+    scheduledDate, // optional — 'YYYY-MM-DD'
+    scheduledTime, // optional — 'HH:mm' or ISO datetime
+    startTime, // optional — actual start time
+    endTime, // optional — actual end time
+    resumeTime, // optional — resume after suspension
+    stopTime, // optional — suspension time
+    courtId, // optional — assigned court
+    venueId, // optional — assigned venue
+    courtOrder, // optional — order on court
+    homeParticipantId, // optional — home team participant
+    courtIds, // optional — for TEAM matchUps, allocate courts
   },
-  removePriorValues,        // optional boolean — clear existing schedule timeItems first
-  checkChronology,          // optional boolean — defaults to true; validate time ordering
-  errorOnAnachronism,       // optional boolean — return error on chronological violations
-  proConflictDetection,     // optional boolean — detect pro scheduling conflicts
-  disableNotice,            // optional boolean — suppress modification notices
+  removePriorValues, // optional boolean — clear existing schedule timeItems first
+  checkChronology, // optional boolean — defaults to true; validate time ordering
+  errorOnAnachronism, // optional boolean — return error on chronological violations
+  proConflictDetection, // optional boolean — detect pro scheduling conflicts
+  disableNotice, // optional boolean — suppress modification notices
 });
 ```
 

--- a/src/mutate/matchUps/schedule/scheduleProfileGrid.ts
+++ b/src/mutate/matchUps/schedule/scheduleProfileGrid.ts
@@ -21,7 +21,97 @@ type ScheduleProfileGridArgs = {
   clearScheduleDates?: boolean;
   minCourtGridRows?: number;
   scheduleDates?: string[];
+  courtIds?: string[];
 };
+
+type RoundProfile = {
+  structureId: string;
+  roundNumber: number;
+  drawId: string;
+  roundSegment?: { segmentsCount: number; segmentNumber: number };
+};
+
+function getSegmentMatchUpIds(
+  allMatchUps: any[],
+  structureId: string,
+  roundNumber: number,
+  drawId: string,
+  segmentsCount: number,
+  segmentNumber: number,
+): string[] {
+  const roundMatchUps = allMatchUps.filter(
+    (rm: any) => rm.structureId === structureId && rm.roundNumber === roundNumber && rm.drawId === drawId,
+  );
+  const chunkSize = Math.ceil(roundMatchUps.length / segmentsCount);
+  const sortedIds = roundMatchUps
+    .sort((a: any, b: any) => (a.roundPosition ?? 0) - (b.roundPosition ?? 0))
+    .map((rm: any) => rm.matchUpId);
+  const segStart = (segmentNumber - 1) * chunkSize;
+  return sortedIds.slice(segStart, segStart + chunkSize);
+}
+
+function findRoundMatchUps(
+  roundProfile: RoundProfile,
+  allMatchUps: any[],
+  containedStructureIds: Record<string, string>,
+): any[] {
+  const { structureId, roundNumber, drawId, roundSegment } = roundProfile;
+  const effectiveStructureId = containedStructureIds[structureId] ?? structureId;
+
+  const segmentIds = roundSegment
+    ? new Set(
+        getSegmentMatchUpIds(
+          allMatchUps,
+          structureId,
+          roundNumber,
+          drawId,
+          roundSegment.segmentsCount,
+          roundSegment.segmentNumber,
+        ),
+      )
+    : null;
+
+  return allMatchUps.filter((m: any) => {
+    if (m.matchUpStatus === BYE) return false;
+    if (m.schedule?.courtId) return false;
+    if (m.schedule?.courtOrder) return false;
+    if (m.roundNumber !== roundNumber) return false;
+    if (m.drawId !== drawId) return false;
+
+    const mStructureId = containedStructureIds[m.structureId] ?? m.structureId;
+    if (mStructureId !== effectiveStructureId) return false;
+
+    return segmentIds ? segmentIds.has(m.matchUpId) : true;
+  });
+}
+
+function resolveTargetCourtIds(dateCourtIds: string[], courtIdsFilter: Set<string> | null): string[] | undefined {
+  if (courtIdsFilter) return dateCourtIds;
+  return dateCourtIds.length ? dateCourtIds : undefined;
+}
+
+function collectVenuePlan(
+  dateProfile: any,
+  courtsByVenue: Map<string, string[]>,
+  courtIdsFilter: Set<string> | null,
+  allMatchUps: any[],
+  containedStructureIds: Record<string, string>,
+): { dateMatchUps: any[]; dateCourtIds: string[] } {
+  const dateMatchUps: any[] = [];
+  const dateCourtIds: string[] = [];
+
+  for (const venueProfile of dateProfile.venues ?? []) {
+    const allVenueCourtIds = courtsByVenue.get(venueProfile.venueId) ?? [];
+    const venueCourtIds = courtIdsFilter ? allVenueCourtIds.filter((id) => courtIdsFilter.has(id)) : allVenueCourtIds;
+    dateCourtIds.push(...venueCourtIds);
+
+    for (const roundProfile of venueProfile.rounds ?? []) {
+      dateMatchUps.push(...findRoundMatchUps(roundProfile, allMatchUps, containedStructureIds));
+    }
+  }
+
+  return { dateMatchUps, dateCourtIds };
+}
 
 /**
  * Profile-driven grid scheduling (pro scheduling).
@@ -40,7 +130,10 @@ export function scheduleProfileGrid(params: ScheduleProfileGridArgs) {
     clearScheduleDates,
     scheduleDates = [],
     tournamentRecords,
+    courtIds,
   } = params;
+
+  const courtIdsFilter = Array.isArray(courtIds) ? new Set(courtIds) : null;
 
   const paramsCheck = checkRequiredParameters(params, [
     { [TOURNAMENT_RECORDS]: true },
@@ -121,63 +214,23 @@ export function scheduleProfileGrid(params: ScheduleProfileGridArgs) {
     const scheduledDate = extractDate(dateProfile.scheduleDate);
 
     // Collect matchUps for this date based on profile round ordering
-    const dateMatchUps: any[] = [];
-    const dateCourtIds: string[] = [];
-
-    for (const venueProfile of dateProfile.venues ?? []) {
-      const venueCourtIds = courtsByVenue.get(venueProfile.venueId) ?? [];
-      dateCourtIds.push(...venueCourtIds);
-
-      for (const roundProfile of venueProfile.rounds ?? []) {
-        const { structureId, roundNumber, drawId, roundSegment } = roundProfile;
-
-        // Resolve the effective structureId (handle round robin container)
-        const effectiveStructureId = containedStructureIds[structureId] ?? structureId;
-
-        // Find matching unscheduled matchUps
-        const roundMatchUps = (allMatchUps ?? []).filter((m: any) => {
-          if (m.matchUpStatus === BYE) return false;
-          if (m.schedule?.courtId) return false; // already has a court assignment
-          if (m.schedule?.courtOrder) return false; // already grid-positioned
-
-          const mStructureId = containedStructureIds[m.structureId] ?? m.structureId;
-          if (mStructureId !== effectiveStructureId) return false;
-          if (m.roundNumber !== roundNumber) return false;
-          if (m.drawId !== drawId) return false;
-
-          // Handle round segments
-          if (roundSegment) {
-            const segmentsCount = roundSegment.segmentsCount;
-            const segmentNumber = roundSegment.segmentNumber;
-            const chunkSize = Math.ceil(
-              (allMatchUps ?? []).filter(
-                (rm: any) => rm.structureId === m.structureId && rm.roundNumber === roundNumber && rm.drawId === drawId,
-              ).length / segmentsCount,
-            );
-            const sortedPositions = (allMatchUps ?? [])
-              .filter(
-                (rm: any) => rm.structureId === m.structureId && rm.roundNumber === roundNumber && rm.drawId === drawId,
-              )
-              .sort((a: any, b: any) => (a.roundPosition ?? 0) - (b.roundPosition ?? 0))
-              .map((rm: any) => rm.matchUpId);
-            const segStart = (segmentNumber - 1) * chunkSize;
-            const segEnd = segStart + chunkSize;
-            const segmentIds = sortedPositions.slice(segStart, segEnd);
-            return segmentIds.includes(m.matchUpId);
-          }
-
-          return true;
-        });
-
-        dateMatchUps.push(...roundMatchUps);
-      }
-    }
+    const { dateMatchUps, dateCourtIds } = collectVenuePlan(
+      dateProfile,
+      courtsByVenue,
+      courtIdsFilter,
+      allMatchUps ?? [],
+      containedStructureIds,
+    );
 
     if (!dateMatchUps.length) continue;
+    // When the caller has explicitly filtered courts and nothing remains for
+    // this date's venues, skip — falling back to "all courts" would defeat
+    // the filter.
+    if (courtIdsFilter && !dateCourtIds.length) continue;
 
     // Run proAutoSchedule for this date with the collected matchUps
     const gridResult: any = proAutoSchedule({
-      courtIds: dateCourtIds.length ? dateCourtIds : undefined,
+      courtIds: resolveTargetCourtIds(dateCourtIds, courtIdsFilter),
       scheduleCompletedMatchUps,
       minCourtGridRows,
       tournamentRecords,

--- a/src/mutate/matchUps/schedule/scheduleProfileRounds.ts
+++ b/src/mutate/matchUps/schedule/scheduleProfileRounds.ts
@@ -27,6 +27,7 @@ type ScheduleProfileRoundsArgs = {
   scheduleDates?: string[];
   periodLength?: number;
   useGarman?: boolean;
+  courtIds?: string[];
   dryRun?: boolean;
   pro?: boolean;
 };
@@ -40,6 +41,7 @@ export function scheduleProfileRounds(params: ScheduleProfileRoundsArgs) {
     tournamentRecords,
     periodLength,
     useGarman,
+    courtIds,
     dryRun,
     pro,
   } = params;
@@ -101,10 +103,14 @@ export function scheduleProfileRounds(params: ScheduleProfileRoundsArgs) {
     clearScheduledMatchUps({ tournamentRecords, scheduledDates });
   }
 
-  const courts = getVenuesAndCourts({
+  const allCourts = getVenuesAndCourts({
     ignoreDisabled: false,
     tournamentRecords,
   }).courts as any[];
+
+  const courts = Array.isArray(courtIds)
+    ? allCourts.filter((court: any) => courtIds.includes(court.courtId))
+    : allCourts;
 
   const { matchUps } = allCompetitionMatchUps({
     matchUpFilters: { matchUpTypes: [SINGLES, DOUBLES] },

--- a/src/tests/mutations/scheduling/scheduleProfileCourtIds.test.ts
+++ b/src/tests/mutations/scheduling/scheduleProfileCourtIds.test.ts
@@ -1,0 +1,124 @@
+import { mocksEngine } from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { expect, it, describe } from 'vitest';
+
+const startDate = '2024-06-15';
+const endDate = '2024-06-16';
+
+describe('scheduleProfile courtIds filter', () => {
+  it('scheduleProfileGrid only places matchUps on courts in courtIds', () => {
+    const venueId = 'venue-1';
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      venueProfiles: [{ venueName: 'CC', venueAbbreviation: 'CC', courtsCount: 4, venueId }],
+      drawProfiles: [{ drawSize: 16 }],
+      startDate,
+      endDate,
+    });
+
+    let result: any = tournamentEngine.setState(tournamentRecord);
+    expect(result.success).toEqual(true);
+
+    const { courts } = tournamentEngine.getVenuesAndCourts();
+    const allCourtIds = courts.map((c: any) => c.courtId);
+    const targetCourtIds = allCourtIds.slice(0, 2);
+    const otherCourtIds = new Set(allCourtIds.slice(2));
+
+    const { matchUps } = tournamentEngine.allCompetitionMatchUps({ inContext: true });
+    const { tournamentId, eventId, drawId, structureId } = matchUps[0];
+
+    tournamentEngine.setSchedulingProfile({
+      schedulingProfile: [
+        {
+          scheduleDate: startDate,
+          venues: [{ venueId, rounds: [{ tournamentId, eventId, drawId, structureId, roundNumber: 1 }] }],
+        },
+      ],
+    });
+
+    result = tournamentEngine.scheduleProfileGrid({
+      scheduleDates: [startDate],
+      courtIds: targetCourtIds,
+    });
+    expect(result.success).toEqual(true);
+
+    const { matchUps: after } = tournamentEngine.allCompetitionMatchUps({ inContext: true });
+    const placedOnDay = after.filter((m: any) => m.schedule?.scheduledDate === startDate && m.schedule?.courtId);
+    expect(placedOnDay.length).toBeGreaterThan(0);
+    expect(placedOnDay.every((m: any) => !otherCourtIds.has(m.schedule.courtId))).toEqual(true);
+  });
+
+  it('scheduleProfileGrid with empty courtIds places nothing', () => {
+    const venueId = 'venue-empty';
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      venueProfiles: [{ venueName: 'V', venueAbbreviation: 'V', courtsCount: 2, venueId }],
+      drawProfiles: [{ drawSize: 8 }],
+      startDate,
+      endDate,
+    });
+
+    let result: any = tournamentEngine.setState(tournamentRecord);
+    expect(result.success).toEqual(true);
+
+    const { matchUps } = tournamentEngine.allCompetitionMatchUps({ inContext: true });
+    const { tournamentId, eventId, drawId, structureId } = matchUps[0];
+
+    tournamentEngine.setSchedulingProfile({
+      schedulingProfile: [
+        {
+          scheduleDate: startDate,
+          venues: [{ venueId, rounds: [{ tournamentId, eventId, drawId, structureId, roundNumber: 1 }] }],
+        },
+      ],
+    });
+
+    result = tournamentEngine.scheduleProfileGrid({
+      scheduleDates: [startDate],
+      courtIds: [],
+    });
+    expect(result.success).toEqual(true);
+
+    const { matchUps: after } = tournamentEngine.allCompetitionMatchUps({ inContext: true });
+    const placed = after.filter((m: any) => m.schedule?.courtId);
+    expect(placed.length).toEqual(0);
+  });
+
+  it('scheduleProfileRounds only assigns times on courts in courtIds', () => {
+    const profileStart = '2022-01-01';
+    const profileEnd = '2022-01-07';
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      venueProfiles: [{ venueId: 'venueId1', courtsCount: 8, startTime: '08:00', endTime: '20:00' }],
+      drawProfiles: [{ drawId: 'drawId1', drawSize: 32 }],
+      startDate: profileStart,
+      endDate: profileEnd,
+    });
+
+    let result: any = tournamentEngine.setState(tournamentRecord);
+    expect(result.success).toEqual(true);
+
+    const { courts } = tournamentEngine.getVenuesAndCourts();
+    const allCourtIds = courts.map((c: any) => c.courtId);
+    const targetCourtIds = allCourtIds.slice(0, 4);
+    const otherCourtIds = new Set(allCourtIds.slice(4));
+
+    const { rounds } = tournamentEngine.getRounds();
+    const drawRounds = rounds.filter(({ drawId }: any) => drawId === 'drawId1');
+
+    result = tournamentEngine.setSchedulingProfile({
+      schedulingProfile: [
+        {
+          scheduleDate: profileStart,
+          venues: [{ venueId: 'venueId1', rounds: drawRounds }],
+        },
+      ],
+    });
+    expect(result.success).toEqual(true);
+
+    result = tournamentEngine.scheduleProfileRounds({ courtIds: targetCourtIds, pro: true });
+    expect(result.success).toEqual(true);
+
+    const { matchUps: after } = tournamentEngine.allCompetitionMatchUps();
+    const scheduledWithCourt = after.filter((m: any) => m.schedule?.courtId);
+    expect(scheduledWithCourt.length).toBeGreaterThan(0);
+    expect(scheduledWithCourt.every((m: any) => !otherCourtIds.has(m.schedule.courtId))).toEqual(true);
+  });
+});


### PR DESCRIPTION
## Summary

Switches \`npm-publish.yml\` from \`push: tags\` to \`release: published\` so release-please-created releases actually publish to npm.

### Background

When release-please-action creates a release, it pushes the tag using \`GITHUB_TOKEN\`. GitHub's loop-prevention rule silently suppresses \`push\` events triggered by \`GITHUB_TOKEN\`, so the existing \`push: tags\` trigger never fired — which is why **v3.1.5 has a GitHub release and a git tag but is not on npm.** \`release: published\` is delivered regardless of which token created the release, closing the gap.

### Other changes

- **\`workflow_dispatch\` input** — manual backfill escape hatch. Pass a tag like \`v3.1.5\` to republish from an existing tag without cutting a new release. Useful here to backfill v3.1.5 once this PR lands (although v3.1.5 is no-op content-wise, so could just be skipped).
- **Pinned \`ref:\` on checkout** — \`release: published\` runs on the default branch by default; this checks out the tagged commit instead.

## Test plan

- [ ] After merge, manually trigger via \`gh workflow run npm-publish.yml -f tag=v3.1.5\` to verify the dispatch path works (or skip — v3.1.5 is no-op).
- [ ] Next time a release-please PR merges, confirm \`Publish to npm\` fires automatically and lands on npm with the right dist-tag.