### PR TITLE
ci: mint GitHub App token for release-please so release events fire downstream

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,14 +2,28 @@ name: release-please
 
 # release-please maintains a perpetual release PR on master that
 # accumulates conventional commits since the last release. Merging
-# the PR creates a GitHub release + a `v{version}` tag, which fires
-# `npm-publish.yml` (tag-triggered) to push the package to npm.
+# the PR creates a GitHub release + a `v{version}` tag.
+#
+# We mint a token from a GitHub App (instead of using the default
+# GITHUB_TOKEN) so that the `release: published` event actually fires
+# `npm-publish.yml`. GitHub silently suppresses workflow events
+# triggered by GITHUB_TOKEN to prevent recursive runs; minting via
+# an App sidesteps that rule. (PR #4278 swapped npm-publish from
+# `push: tags` to `release: published` under the assumption that
+# the loop-prevention only applied to `push` — it applies to
+# `release` too. v3.2.0 was released but never auto-published.)
+#
+# Required repo secrets:
+#   RELEASE_BOT_APP_ID         — numeric App ID
+#   RELEASE_BOT_PRIVATE_KEY    — PEM contents (BEGIN/END markers included)
+#
+# The App needs Contents: Write + Pull requests: Write on this repo.
 #
 # Day-to-day flow:
 #   1. Land feature/fix PRs on master with conventional commits
 #      (feat:, fix:, chore:, docs:, etc.)
 #   2. The bot updates a `chore: release X.Y.Z` PR automatically
-#   3. Merge the release PR → publish fires
+#   3. Merge the release PR → GitHub release fires `npm-publish.yml`
 #
 # To force a specific version, edit `.release-please-manifest.json`
 # on master directly.
@@ -27,8 +41,16 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Mint App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v5
         with:
+          token: ${{ steps.app-token.outputs.token }}
           target-branch: master
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Replace the implicit `GITHUB_TOKEN` in `release-please.yml` with a token minted from a GitHub App, so that the GitHub release created by release-please-action actually fires `release: published` and triggers `npm-publish.yml`.

## Background

PR #4278 swapped `npm-publish.yml` from `push: tags` to `release: published` to close the auto-publish gap, but **v3.2.0 was released and still didn't publish to npm**. Root cause: GitHub's loop-prevention rule — *"workflows triggered by `GITHUB_TOKEN` cannot trigger other workflows"* — applies to the `release` event too, not only to `push`. Since release-please-action authored the release with the default `GITHUB_TOKEN`, the resulting `release: published` event fired no downstream workflows.

Fix: mint a token from a GitHub App and pass it to release-please-action via the `token:` input. Releases authored under the App identity fire `release: published` normally.

## Required setup (manual, before merge)

In the CourtHive org:

1. **Create a GitHub App** (Settings → Developer settings → GitHub Apps → New GitHub App)
   - Permissions: **Contents: Write**, **Pull requests: Write**
   - No webhook needed
   - Generate a private key (downloads a `.pem` file)
2. **Install the App** on the `competition-factory` repo
3. **Add two repo secrets** (Settings → Secrets and variables → Actions):
   - `RELEASE_BOT_APP_ID` — numeric App ID (visible on the App's settings page)
   - `RELEASE_BOT_PRIVATE_KEY` — full PEM contents (BEGIN/END markers included)

Once both secrets exist, this PR can land.

## Test plan

- [ ] Confirm both repo secrets are present before merging
- [ ] After merge, the next `chore: release X.Y.Z` PR from release-please will be authored by the App (commit author shows the App's bot identity, not `github-actions[bot]`)
- [ ] When that release PR is merged, `Publish to npm` should fire automatically and land the version on npm — no `workflow_dispatch` needed

## Cleanup once verified

- Backfill v3.2.0 to npm via `gh workflow run npm-publish.yml -f tag=v3.2.0` (separately — not part of this PR)