### PR TITLE
chore: migrate Renovate base preset to recommended

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base", ":semanticCommits"],
+  "extends": ["config:recommended", ":semanticCommits"],
   "packageRules": [
     {
       "matchPackageNames": ["tods-competition-factory"],


### PR DESCRIPTION
## Summary
- migrate Renovate's deprecated `config:base` preset to `config:recommended`
- preserve the existing semantic commits preset and package rule for `tods-competition-factory`

## Verification
- `python3 -m json.tool renovate.json`
- `git diff --check`

This addresses the Renovate Dependency Dashboard config migration notice in #390.