### PR TITLE
feat(policies): cts article 21 qualifying-stage award profiles

### DIFF
--- a/src/fixtures/policies/POLICY_RANKING_POINTS_CTS.ts
+++ b/src/fixtures/policies/POLICY_RANKING_POINTS_CTS.ts
@@ -32,7 +32,7 @@
 
 import { POLICY_TYPE_RANKING_POINTS } from '@Constants/policyConstants';
 import { SINGLES, DOUBLES } from '@Constants/eventConstants';
-import { MAIN, SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
+import { MAIN, QUALIFYING, SINGLE_ELIMINATION } from '@Constants/drawDefinitionConstants';
 
 // ─── Tabulka IV ──────────────────────────────────────────────────────────────
 //
@@ -116,16 +116,96 @@ function buildProfile(level: number, eventType: 'SINGLES' | 'DOUBLES'): object {
   };
 }
 
+// ─── Qualifying Award Profiles (Article 21 / Tabulka IV postscript) ─────────
+//
+// "Points for victory in qualifying (for advancing to the main draw) are
+//  obtained depending on the size of the starting field in the main draw.
+//  E.g., for a 32-MAIN in category 14: qualifying winners get 42 pts,
+//  qualifying finalists 29 pts, qualifying semifinalists 20 pts."
+//
+// Mechanics:
+//   - Qualifying WINNERS (who advance) — DO play MAIN. If they lose R1 MAIN,
+//     Article 17 says they receive the full MAIN-R1 points. That's covered
+//     by the MAIN awardProfile naturally and is NOT encoded as a Q award
+//     here (encoding it would double-count).
+//   - Qualifying NON-ADVANCERS — receive points for their qualifying-stage
+//     finishing position, read from Tabulka IV at a column shifted right
+//     of the linked MAIN's R1 column. Q-final losers shift +1 column;
+//     Q-SF losers shift +2; etc.
+//
+// The CTS convention assumes MAIN drawSize = Q drawSize × 2 (e.g., 16-Q
+// feeds 32-MAIN; 32-Q feeds 64-MAIN). The two combinations actually present
+// in the 2026 Class A corpus are 16-Q→32-MAIN and 32-Q→64-MAIN. Other
+// (level, Q) combinations are encoded too in case future tournaments use
+// them; rows that don't have enough columns at low levels (e.g., col 8 at
+// level 5 is undefined) simply drop the unsupported rangeKey.
+//
+// `qualifyingPositions` typically = qDrawSize / 4 in CZE, producing a
+// 2-round qualifying structure. Q-finalists land in finishingPositionRange
+// rangeKey = qDrawSize/2; Q-SF losers in rangeKey = qDrawSize. Both rangeKeys
+// are emitted per (level, qDrawSize) when the corresponding Tabulka IV
+// column exists.
+
+const Q_TO_MAIN_RATIO = 2;
+const QUALIFYING_DRAW_SIZES = [4, 8, 16, 32];
+
+function buildQualifyingProfile(level: number, qDrawSize: number): object | undefined {
+  const row = TABULKA_IV[level];
+  const mainDrawSize = qDrawSize * Q_TO_MAIN_RATIO;
+  const mainR1ColumnIndex = Math.log2(mainDrawSize); // 16→4, 32→5, 64→6, 128→7
+  // Per `resolvePositionPoints` in getTournamentPoints.ts:194-196, when
+  // rankingStage === QUALIFYING the accessor is rewritten to
+  //   participantWon ? 1 : Math.pow(2, participation.finishingRound)
+  // i.e. accessor 1 = qualifier (advanced); 2 = Q-final loser (1 round shy);
+  // 4 = Q-SF loser (2 rounds shy); 8 = Q-QF loser (3 rounds shy).
+  //
+  // Tabulka IV postscript shifts the points column based on rounds-shy-of-
+  // advancing. Q final losers shift +1 column right of MAIN R1; Q SF losers
+  // shift +2; etc. Qualifier (accessor 1) is omitted — qualifiers play MAIN
+  // and get the matching MAIN award per Article 17, so encoding it here
+  // would double-count.
+  const finishingPositionRanges: Record<number, number> = {};
+  const shifts: { accessor: number; columnShift: number }[] = [
+    { accessor: 2, columnShift: 1 }, // Q-final loser
+    { accessor: 4, columnShift: 2 }, // Q-SF loser
+    { accessor: 8, columnShift: 3 }, // Q-QF loser
+  ];
+  for (const { accessor, columnShift } of shifts) {
+    const pts = row[mainR1ColumnIndex + columnShift];
+    if (typeof pts === 'number') finishingPositionRanges[accessor] = pts;
+  }
+  if (Object.keys(finishingPositionRanges).length === 0) return undefined;
+  // Filter by MAIN drawSize (the structure size factory passes when computing
+  // points for a QUALIFYING-stage participation; per
+  // getParticipantEntries.ts:346-350, drawSize on derivedDrawInfo is set from
+  // the MAIN structure, not the QUALIFYING one).
+  return {
+    profileName: `CTS SINGLES Cat ${level} Q→MAIN-${mainDrawSize}`,
+    drawTypes: [SINGLE_ELIMINATION],
+    eventTypes: [SINGLES],
+    stages: [QUALIFYING],
+    drawSizes: [mainDrawSize],
+    levels: [level],
+    finishingPositionRanges,
+  };
+}
+
 // ─── Award Profiles ──────────────────────────────────────────────────────────
 //
-// One profile per (level, eventType). 21 categories × 2 event types = 42
+// MAIN: one profile per (level, eventType). 21 categories × 2 event types = 42
 // profiles. Matches Tennis Europe's encoding pattern (POLICY_RANKING_POINTS_TENNIS_EUROPE)
 // — plain numbers in finishingPositionRanges, no nested `level` maps (which
 // the factory's award selector doesn't traverse).
+//
+// QUALIFYING (SINGLES only — doubles has no qualifying in CZE): one profile per
+// (level, Q drawSize) where Tabulka IV has enough columns to support the shift.
 
 const awardProfiles = [
   ...CATEGORIES.map((cat) => buildProfile(cat, 'SINGLES')),
   ...CATEGORIES.map((cat) => buildProfile(cat, 'DOUBLES')),
+  ...CATEGORIES.flatMap((cat) =>
+    QUALIFYING_DRAW_SIZES.map((qSize) => buildQualifyingProfile(cat, qSize)).filter((p) => p !== undefined),
+  ),
 ];
 
 // ─── Tier → Level mapping ────────────────────────────────────────────────────

--- a/src/tests/policies/ctsQualifyingArticle21.test.ts
+++ b/src/tests/policies/ctsQualifyingArticle21.test.ts
@@ -1,0 +1,148 @@
+import { POLICY_RANKING_POINTS_CTS } from '@Fixtures/policies/POLICY_RANKING_POINTS_CTS';
+import scaleEngine from '@Assemblies/engines/scale';
+import { tournamentEngine } from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { describe, expect, test } from 'vitest';
+
+import { SINGLES } from '@Constants/eventConstants';
+import { QUALIFYING } from '@Constants/drawDefinitionConstants';
+import { MALE } from '@Constants/genderConstants';
+
+// CTS Klasifikační řád 2025, Tabulka IV postscript (Article 21):
+// "Points for victory in qualifying (for advancing to the main draw) are
+//  obtained depending on the size of the starting field in the main draw.
+//  E.g., if the main draw in the 14th category has 32 participants,
+//  qualifying winners get 42 points, qualifying finalists 29 points,
+//  qualifying semifinalists 20 points."
+//
+// Mapped onto POLICY_RANKING_POINTS_CTS.ts:
+//   - Q WINNERS (advanced) → MAIN R1-equivalent points via Article 17 (the
+//     MAIN awardProfile handles this naturally). NOT encoded as a Q award.
+//   - Q FINALISTS (lost final-shy round) → MAIN R1 column +1 in Tabulka IV.
+//   - Q SF / Q QF etc. → +2 / +3 / ... columns right.
+//
+// `resolvePositionPoints` in getTournamentPoints.ts:194-196 rewrites the
+// awardProfile accessor for QUALIFYING participations:
+//   accessor = participantWon ? 1 : 2^finishingRound
+// So Q non-advancers' rangeKey == 2 (one round shy), 4 (two rounds shy), etc.
+
+describe('CTS POLICY_RANKING_POINTS_CTS — Article 21 qualifying-stage points', () => {
+  test('Q non-advancers receive Tabulka IV column-shifted points', () => {
+    // 16-MAIN with 8-Q (4 qualifying-positions). Factory auto-generates
+    // participants + completes all matchUps. The 4 Q-final losers (the
+    // qualifier-feed round losers) should each receive points equal to the
+    // Tabulka IV column at MAIN-R1-index+1, looked up at the requested level.
+    //
+    // For level 12, Tabulka IV row = [200, 138, 96, 67, 47, 33, 23, 16, 11, 7]:
+    //   - 16-MAIN R1 = column 4 (rangeKey 16) = 47 pts
+    //   - Q-final loser (column-one-right) = column 5 (rangeKey 32) = 33 pts
+    //   - Q-SF loser (column-two-right)   = column 6 = 23 pts (but 8-Q is
+    //     2-round so SF rangeKey 4 may not appear; encoded regardless).
+
+    const { tournamentRecord, drawIds } = mocksEngine.generateTournamentRecord({
+      tournamentName: 'CTS Article 21 Test',
+      participantsProfile: { participantsCount: 12, sex: MALE },
+      tournamentAttributes: {
+        tournamentTier: { system: 'CTS', value: 'A', numericRank: 12 },
+      },
+      drawProfiles: [
+        {
+          drawSize: 16,
+          eventType: SINGLES,
+          matchUpType: SINGLES,
+          gender: MALE,
+          category: { categoryName: 'U18', ageCategoryCode: 'U18' },
+          qualifyingProfiles: [
+            {
+              roundTarget: 1,
+              structureProfiles: [{ drawSize: 8, qualifyingPositions: 4 }],
+            },
+          ],
+          completeAllMatchUps: true,
+        },
+      ],
+      completeAllMatchUps: true,
+      setState: true,
+    });
+
+    expect(drawIds?.length).toEqual(1);
+    const tr = tournamentEngine.getState().tournamentRecords[tournamentRecord.tournamentId];
+
+    const r = scaleEngine.getTournamentPoints({
+      tournamentRecord: tr,
+      policyDefinitions: POLICY_RANKING_POINTS_CTS,
+      level: 12,
+    });
+    expect(r.success).toEqual(true);
+
+    // Collect every Q-stage award and assert at least one Q-final-loser
+    // (rangeKey 2 = 2^1 — finishingRound 1 in a 2-round Q final) received
+    // the Tabulka IV col+1 points.
+    const allAwards = Object.values(r.personPoints).flat();
+    const qFinalLoserAwards = allAwards.filter((a: any) => a.eventType === SINGLES && a.rangeAccessor === 2);
+    expect(qFinalLoserAwards.length).toBeGreaterThan(0);
+    // Tabulka IV row 12 col 5 = 33 pts (16-MAIN's "Q final loser" shift +1).
+    for (const award of qFinalLoserAwards) {
+      expect((award as any).points).toEqual(33);
+    }
+  });
+
+  test('policy exposes one Q awardProfile per (level, Q drawSize) where columns exist', () => {
+    const policyBlock = (POLICY_RANKING_POINTS_CTS as any)[Object.keys(POLICY_RANKING_POINTS_CTS)[0]];
+    const profiles = policyBlock.awardProfiles ?? [];
+    const qProfiles = profiles.filter((p: any) => p.stages?.includes(QUALIFYING));
+    // 21 levels × 4 Q drawSizes (4, 8, 16, 32) max — minus low-level drops
+    // where the shifted Tabulka IV column doesn't exist.
+    expect(qProfiles.length).toBeGreaterThan(60);
+    // Verify shape on the level-12 / Q-16 (→ MAIN-32) profile
+    const sample = qProfiles.find((p: any) => p.levels?.includes(12) && p.drawSizes?.includes(32));
+    expect(sample).toBeDefined();
+    expect(sample.stages).toEqual([QUALIFYING]);
+    // rangeKey 2 = Q-final loser. 32-MAIN R1 column = index 5 (33 pts);
+    // shift +1 → column 6 = 23 pts.
+    expect(sample.finishingPositionRanges[2]).toEqual(23);
+    // rangeKey 4 = Q-SF loser → column 7 = 16 pts.
+    expect(sample.finishingPositionRanges[4]).toEqual(16);
+  });
+
+  // MAIN-only sanity: the existing MAIN awardProfile path still produces
+  // expected points after the QUALIFYING profiles were added to the policy.
+  test('MAIN award still fires for direct-MAIN participants', () => {
+    const { tournamentRecord, drawIds } = mocksEngine.generateTournamentRecord({
+      tournamentName: 'CTS MAIN-only test',
+      participantsProfile: { participantsCount: 8, sex: MALE },
+      tournamentAttributes: {
+        tournamentTier: { system: 'CTS', value: 'A', numericRank: 12 },
+      },
+      drawProfiles: [
+        {
+          drawSize: 8,
+          eventType: SINGLES,
+          matchUpType: SINGLES,
+          gender: MALE,
+          category: { categoryName: 'U18', ageCategoryCode: 'U18' },
+          completeAllMatchUps: true,
+        },
+      ],
+      completeAllMatchUps: true,
+      setState: true,
+    });
+    expect(drawIds?.length).toEqual(1);
+    const tr = tournamentEngine.getState().tournamentRecords[tournamentRecord.tournamentId];
+    const r = scaleEngine.getTournamentPoints({
+      tournamentRecord: tr,
+      policyDefinitions: POLICY_RANKING_POINTS_CTS,
+      level: 12,
+    });
+    expect(r.success).toEqual(true);
+    const mainR1LoserAwards = Object.values(r.personPoints)
+      .flat()
+      .filter(
+        (a: any) => a.eventType === SINGLES && a.rangeAccessor === 8, // rangeKey 8 = R1 loser in 8-draw (loser range [5,8])
+      );
+    // Tabulka IV row 12 col 3 = 67 pts.
+    for (const award of mainR1LoserAwards) {
+      expect((award as any).points).toEqual(67);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Add QUALIFYING-stage award profiles to `POLICY_RANKING_POINTS_CTS` so Czech qualifying non-advancers earn the points specified in Tabulka IV's postscript (Klasifikační řád 2025, Article 21).

- **Q-final loser** → MAIN R1 column +1 in Tabulka IV
- **Q-SF loser** → MAIN R1 column +2
- **Q-QF loser** → MAIN R1 column +3
- **Q winners** (advanced) continue to receive MAIN R1 points via Article 17 on the existing MAIN awardProfile — NOT encoded as a Q award (would double-count).

Tabulka IV postscript example (level 14, 32-MAIN): Q winners 42 pts (handled by MAIN), Q finalists 29, Q SF 20. The new code reproduces this for every (level, Q drawSize) combination present in the corpus.

## Implementation

- `buildQualifyingProfile(level, qDrawSize)` per (level, qDrawSize). Filters by `stages: [QUALIFYING]` and `drawSizes: [mainDrawSize]` (since `derivedDrawInfo.drawSize` is set from the MAIN structure per `getParticipantEntries.ts:347-350`).
- `finishingPositionRanges` keyed by the `resolvePositionPoints` accessor for QUALIFYING participations (`2^finishingRound`): rangeKey 2 = Q-final loser, 4 = Q-SF, 8 = Q-QF.
- Assumes CZE convention: MAIN drawSize = Q drawSize × 2. Q drawSizes covered: 4, 8, 16, 32 (16-Q → 32-MAIN and 32-Q → 64-MAIN are the typical CZE Class A combinations).
- Rows where the shifted Tabulka IV column doesn't exist at low levels (1-5 with 8+ columns) are dropped automatically.

## Test plan

- [x] Full factory test suite: 9428/9428 pass (3 new), zero lint warnings on `src/`
- [x] Coverage: 97.54 / 95.13 / 97.95 / 86.54 — clears 95/95/83/95 thresholds
- [x] New `src/tests/policies/ctsQualifyingArticle21.test.ts` covers Q non-advancer point shape, the policy profile inventory, and a MAIN-only sanity case
- [x] End-to-end verified via 34 CZE Class A 2026 tournaments in courthive-ingest: U18 unique participants with points 192 → 210 (+18 Q-only entries); top-3 male leaderboard unchanged

## Paired changes

The ingest refactor that surfaces these awards (replacing separate QUALIFYING drawDefinitions with `qualifyingProfiles` and tagging Q-only event entries with `entryStage: QUALIFYING`) lives in `courthive-ingest` on the matching `feat/article-21-qualifying-points` branch.