### PR TITLE
docs: correct site url to courthive.github.io

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   title: 'Competition Factory',
   tagline: 'Open-source engine for tournament management — draws, scheduling, scoring, and more.',
-  url: 'https://courthive.github.com',
+  url: 'https://courthive.github.io',
   baseUrl: '/competition-factory/',
   onBrokenLinks: 'warn',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
The Docusaurus `url` read `github.com`; GitHub Pages serves the site at `courthive.github.io`. Cosmetic config fix — the gh-pages deploy branch is unaffected. Typed `docs:` (not `fix:`) so it does not cut an npm release.