### PR TITLE
feat(scales): fall back to tier.numericRank when a policy declares no tierToLevel

### DIFF
--- a/src/query/scales/getEventRankingPoints.ts
+++ b/src/query/scales/getEventRankingPoints.ts
@@ -130,12 +130,18 @@ function collectPersonAwards({ personPoints, personToParticipant, eventDrawIds, 
 }
 
 /**
- * Resolve a numeric ranking level from a TierClassification using the
- * policy's tierToLevel mapping. Returns undefined if no match.
+ * Resolve a numeric ranking level from a TierClassification. Prefer the policy's
+ * `tierToLevel[system][value]` mapping; fall back to the tier's own
+ * `numericRank` when the policy declares no mapping for that system/value. This
+ * lets a federation that stamps the level directly on the tier (e.g. an ingest
+ * adapter setting `numericRank` to the resolved level) drive ranking points
+ * without every policy enumerating that federation's categories. Returns
+ * undefined when neither source yields a level.
  */
 function resolveLevelFromTier(tier: any, policy: any): number | undefined {
-  if (!tier?.system || !tier?.value || !policy?.tierToLevel) return undefined;
-  return policy.tierToLevel[tier.system]?.[tier.value];
+  if (!tier?.system || !tier?.value) return undefined;
+  const mapped = policy?.tierToLevel?.[tier.system]?.[tier.value];
+  return mapped ?? tier.numericRank;
 }
 
 function collectLookupAwards({ points, participantLookup, eventDrawIds, eventAwards }) {

--- a/src/tests/queries/scales/tierToLevel.test.ts
+++ b/src/tests/queries/scales/tierToLevel.test.ts
@@ -1,3 +1,4 @@
+import { POLICY_RANKING_POINTS_TENNIS_EUROPE } from '@Tests/fixtures/policies/POLICY_RANKING_POINTS_TENNIS_EUROPE';
 import mocksEngine from '@Assemblies/engines/mock';
 import tournamentEngine from '@Engines/syncEngine';
 import { expect, it, describe } from 'vitest';
@@ -13,7 +14,7 @@ const TIER_AWARE_POLICY = {
   [POLICY_TYPE_RANKING_POINTS]: {
     policyName: 'Tier Test Policy',
     tierToLevel: {
-      ITF_JUNIOR: { 'J500': 4, 'J300': 5, 'J200': 6 },
+      ITF_JUNIOR: { J500: 4, J300: 5, J200: 6 },
       ATP: { 'Grand Slam': 1, '1000': 2, '500': 3, '250': 4 },
     },
     awardProfiles: [
@@ -124,5 +125,86 @@ describe('tierToLevel — ranking points auto-resolution', () => {
     });
 
     expect(result.error).toBeUndefined();
+  });
+});
+
+describe('tierToLevel — numericRank fallback', () => {
+  // Level-keyed finishingPositionRanges so a winner produces a real award:
+  // position 1 → 500 at level 2, 60 at level 5.
+  const LEVELED_POLICY = {
+    [POLICY_TYPE_RANKING_POINTS]: {
+      policyName: 'leveled',
+      tierToLevel: { MAPPED: { known: 2 } },
+      awardProfiles: [
+        {
+          profileName: 'leveled',
+          eventTypes: ['SINGLES'],
+          stages: ['MAIN'],
+          category: { ageCategoryCodes: ['U18'] },
+          finishingPositionRanges: { 1: { level: { 2: 500, 5: 60 } } },
+        },
+      ],
+    },
+  };
+
+  function winnerPoints(tier: any): number {
+    mocksEngine.generateTournamentRecord({
+      eventProfiles: [
+        {
+          eventType: 'SINGLES',
+          category: { ageCategoryCode: 'U18' },
+          drawProfiles: [{ drawSize: 8, completionGoal: 8 }],
+        },
+      ],
+      setState: true,
+    });
+    tournamentEngine.setTournamentTier({ tournamentTier: tier });
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    const eventId = tournamentRecord.events[0].eventId;
+    const result: any = tournamentEngine.getEventRankingPoints({ policyDefinitions: LEVELED_POLICY, eventId });
+    expect(result.error).toBeUndefined();
+    return result.eventAwards?.[0]?.points ?? 0;
+  }
+
+  it('falls back to tier.numericRank when the policy declares no mapping', () => {
+    // OTHER is absent from tierToLevel → numericRank 5 → level 5 → 60.
+    expect(winnerPoints({ system: 'OTHER', value: 'x', numericRank: 5 })).toBe(60);
+  });
+
+  it('policy tierToLevel takes precedence over numericRank', () => {
+    // MAPPED.known → level 2 (→ 500), ignoring the bogus numericRank 5.
+    expect(winnerPoints({ system: 'MAPPED', value: 'known', numericRank: 5 })).toBe(500);
+  });
+
+  it('real TENNIS_EUROPE policy (no tierToLevel) resolves via the stamped numericRank', () => {
+    function teWinnerPoints(numericRank: number): number {
+      mocksEngine.generateTournamentRecord({
+        eventProfiles: [
+          {
+            eventType: 'SINGLES',
+            category: { ageCategoryCode: '16U' },
+            drawProfiles: [{ drawSize: 16, completionGoal: 16 }],
+          },
+        ],
+        setState: true,
+      });
+      // The TE policy carries no tierToLevel — the adapter-stamped numericRank is the level.
+      tournamentEngine.setTournamentTier({
+        tournamentTier: { system: 'TENNIS_EUROPE', value: `cat-${numericRank}`, numericRank },
+      });
+      const { tournamentRecord } = tournamentEngine.getTournament();
+      const eventId = tournamentRecord.events[0].eventId;
+      const result: any = tournamentEngine.getEventRankingPoints({
+        policyDefinitions: POLICY_RANKING_POINTS_TENNIS_EUROPE,
+        eventId,
+      });
+      expect(result.error).toBeUndefined();
+      return result.eventAwards?.[0]?.points ?? 0;
+    }
+
+    const superPts = teWinnerPoints(2); // Super Category → level 2
+    const cat3Pts = teWinnerPoints(5); // Category 3 → level 5
+    expect(superPts).toBeGreaterThan(0);
+    expect(superPts).toBeGreaterThan(cat3Pts);
   });
 });


### PR DESCRIPTION
`resolveLevelFromTier` now prefers `policy.tierToLevel[system][value]` and falls back to the tier's `numericRank`. Lets a federation that stamps the resolved level on the tier (the courthive-ingest TS adapter does this for Tennis Europe) drive ranking points without duplicating the category→level mapping into the ranking policy (CFS seed / factory fixture). Policies that define `tierToLevel` are unaffected — the mapping takes precedence. +3 tests (fallback, precedence, real TE policy). Full suite 9472 green.