### PR TITLE
feat(participants): optional Person.birthYear with age/category fallback (CODES)

### DIFF
--- a/documentation/docs/governors/entries-governor.md
+++ b/documentation/docs/governors/entries-governor.md
@@ -61,7 +61,11 @@ When `enforceCategory: true`, validates participants against event category cons
 **Age Validation**:
 
 - Participant must be valid throughout entire event period (start to end date)
-- Requires `person.birthDate` if age restrictions exist
+- Requires `person.birthDate` **or** `person.birthYear` if age restrictions exist.
+  `birthDate` gives exact age; a year-precision `birthYear` falls back to the
+  calendar-year convention (age-in-year = year − birthYear), the standard for
+  junior eligibility when only the birth year is known. `birthDate` is
+  authoritative when both are present.
 - Combined age categories (e.g., `C50-70`) are automatically skipped for individuals
 
 **Rating Validation**:

--- a/documentation/docs/types/assets/person.ts
+++ b/documentation/docs/types/assets/person.ts
@@ -1,6 +1,8 @@
 export const person = {
   addresses: '{\\"type\\":\\"object\\",\\"object\\":\\"address\\",\\"array\\":\\"true\\",\\"required\\":\\"false\\"}',
   birthDate: '{\\"type\\":\\"string\\",\\"required\\":\\"true\\",\\"note\\":\\"\'YYYY-MM-DD\'\\"}',
+  birthYear:
+    '{\\"type\\":\\"number\\",\\"required\\":\\"false\\",\\"note\\":\\"year-precision DOB; age/category falls back to this when birthDate absent\\"}',
   biographicalInformation:
     '{\\"type\\":\\"object\\",\\"object\\":\\"biographicalInformation\\",\\"array\\":\\"true\\",\\"required\\":\\"false\\"}',
   contacts: '{\\"type\\":\\"object\\",\\"object\\":\\"contact\\",\\"array\\":\\"true\\",\\"required\\":\\"false\\"}',

--- a/src/global/schema/tournament.schema.json
+++ b/src/global/schema/tournament.schema.json
@@ -2676,6 +2676,11 @@
             }
           ]
         },
+        "birthYear": {
+          "type": "integer",
+          "minimum": 1900,
+          "maximum": 2200
+        },
         "contacts": {
           "type": "array",
           "items": {

--- a/src/mutate/entries/categoryValidation.ts
+++ b/src/mutate/entries/categoryValidation.ts
@@ -21,6 +21,7 @@ export interface RejectionReason {
 
 export interface AgeRejectionDetails {
   birthDate?: string;
+  birthYear?: number;
   ageAtStart?: number;
   ageAtEnd?: number;
   requiredMin?: number;
@@ -55,6 +56,15 @@ export function getEventDateRange(event: Event, tournamentRecord?: Tournament): 
   }
 
   return { startDate, endDate };
+}
+
+/**
+ * Calendar-year age for a year-precision DOB: the age a player reaches during
+ * `atDate`'s calendar year (year − birthYear). This is the standard junior
+ * eligibility convention used when only the birth year is known.
+ */
+export function calendarYearAge(birthYear: number, atDate: string): number {
+  return Number(extractDate(atDate).split('-')[0]) - birthYear;
 }
 
 /**
@@ -133,10 +143,11 @@ export function validateParticipantAge(
   }
 
   const birthDate = participant.person?.birthDate;
-  if (!birthDate) {
+  const birthYear = participant.person?.birthYear;
+  if (!birthDate && birthYear === undefined) {
     return {
       valid: false,
-      reason: 'Missing birthDate',
+      reason: 'Missing birthDate or birthYear',
       details: {
         requiredMin: effectiveAgeMin,
         requiredMax: effectiveAgeMax,
@@ -144,9 +155,13 @@ export function validateParticipantAge(
     };
   }
 
-  // Check age at event start and end
-  const ageAtStart = calculateAge(birthDate, startDate);
-  const ageAtEnd = calculateAge(birthDate, endDate);
+  // DOB detail echoed in rejections; birthDate is authoritative when present.
+  const dobDetails: { birthDate?: string; birthYear?: number } = birthDate ? { birthDate } : { birthYear };
+
+  // Check age at event start and end. birthDate gives exact age; a year-precision
+  // birthYear falls back to the calendar-year convention (age = year − birthYear).
+  const ageAtStart = birthDate ? calculateAge(birthDate, startDate) : calendarYearAge(birthYear as number, startDate);
+  const ageAtEnd = birthDate ? calculateAge(birthDate, endDate) : calendarYearAge(birthYear as number, endDate);
 
   // Check if valid throughout event period
   const validAtStart = checkAgeInRange(ageAtStart, effectiveAgeMin, effectiveAgeMax);
@@ -164,7 +179,7 @@ export function validateParticipantAge(
       valid: false,
       reason: `Age ${ageAtStart} at event start (${startDate}) outside range [${rangeStr}]`,
       details: {
-        birthDate,
+        ...dobDetails,
         ageAtStart,
         ageAtEnd,
         requiredMin: effectiveAgeMin,
@@ -185,7 +200,7 @@ export function validateParticipantAge(
       valid: false,
       reason: `Age ${ageAtEnd} at event end (${endDate}) outside range [${rangeStr}]`,
       details: {
-        birthDate,
+        ...dobDetails,
         ageAtStart,
         ageAtEnd,
         requiredMin: effectiveAgeMin,
@@ -303,7 +318,12 @@ export function getParticipantName(participant: Participant): string {
   const given = person.standardGivenName || person.passportGivenName;
   const family = person.standardFamilyName || person.passportFamilyName;
 
-  return [given, family].filter(Boolean).join(' ') || participant.participantOtherName || participant.participantName || 'Unknown';
+  return (
+    [given, family].filter(Boolean).join(' ') ||
+    participant.participantOtherName ||
+    participant.participantName ||
+    'Unknown'
+  );
 }
 
 /**

--- a/src/mutate/events/modifyEvent.ts
+++ b/src/mutate/events/modifyEvent.ts
@@ -132,10 +132,13 @@ function checkParticipantAges(params, category) {
   ) {
     for (const individualParticipant of individualParticpants) {
       const birthDate = individualParticipant.person?.birthDate;
-      if (!birthDate) {
+      const birthYear = individualParticipant.person?.birthYear;
+      if (!birthDate && birthYear === undefined) {
         return decorateResult({ result: { error: MISSING_BIRTH_DATE }, stack: params.stack });
       }
-      const birthTime = new Date(birthDate).getTime();
+      // birthDate authoritative; for a year-precision birthYear use a mid-year
+      // representative date (minimises error against the date-boundary checks).
+      const birthTime = new Date(birthDate ?? `${birthYear}-07-01`).getTime();
 
       const startCheck = checkAgeAgainstDetails(birthTime, startAgeDetails, params.stack);
       if (startCheck) return startCheck;
@@ -200,7 +203,7 @@ function getParticipantsProfile({ enteredParticipants }) {
   const enteredParticipantTypes = enteredParticipants.reduce((types: any[], participant) => {
     const genders = participant.person?.sex
       ? [participant.person.sex]
-      : participant.individualParticpants?.map((p) => p.person?.sex) ?? [];
+      : (participant.individualParticpants?.map((p) => p.person?.sex) ?? []);
     genderAccumulator.push(...genders);
     return types.includes(participant.participantType) ? types : types.concat(participant.participantType);
   }, []);
@@ -229,8 +232,7 @@ function checkGenderUpdates({ noFlightsNoDraws, enteredParticipantGenders, event
 }
 
 function checkEventType({ enteredParticipantTypes, eventUpdates, stack }) {
-  const hasMixedTypes =
-    enteredParticipantTypes.includes(INDIVIDUAL) && enteredParticipantTypes.includes(PAIR);
+  const hasMixedTypes = enteredParticipantTypes.includes(INDIVIDUAL) && enteredParticipantTypes.includes(PAIR);
   const validEventTypes = (hasMixedTypes && [HYBRID]) ||
     (enteredParticipantTypes.includes(TEAM) && [TEAM]) ||
     (enteredParticipantTypes.includes(INDIVIDUAL) && [SINGLES, HYBRID]) ||

--- a/src/tests/mutations/events/entries/categoryValidation.test.ts
+++ b/src/tests/mutations/events/entries/categoryValidation.test.ts
@@ -306,7 +306,7 @@ describe('Category Validation in addEventEntries', () => {
     });
 
     it('validates age using ageCategoryCode when ageMin/ageMax not provided', () => {
-      const { tournamentRecord} = mocksEngine.generateTournamentRecord({
+      const { tournamentRecord } = mocksEngine.generateTournamentRecord({
         startDate: '2024-08-01',
         endDate: '2024-08-15',
       });
@@ -1437,6 +1437,67 @@ describe('Category Validation in addEventEntries', () => {
       expect(ratingReason).toBeDefined();
       expect(ratingReason.reason).toContain('High Rating');
       expect(ratingReason.reason).toContain('above maximum');
+    });
+  });
+
+  describe('Year-precision birthYear (CODES)', () => {
+    function setup(person: any, category: any) {
+      const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+        startDate: '2024-08-01',
+        endDate: '2024-08-15',
+      });
+      const participant = { participantId: 'p-by', participantType: INDIVIDUAL, person };
+      tournamentRecord.participants = [participant];
+      tournamentEngine.setState(tournamentRecord);
+      const { eventId } = tournamentEngine.addEvent({ event: { eventName: 'E', eventType: SINGLES, category } }).event;
+      return tournamentEngine.addEventEntries({ participantIds: ['p-by'], enforceCategory: true, eventId });
+    }
+
+    it('accepts a person with only birthYear when calendar-year age is in range', () => {
+      // 2024 − 2008 = 16, within U18 (ageMax 17)
+      const result: any = setup(
+        { birthYear: 2008, standardGivenName: 'Year', standardFamilyName: 'Only', sex: 'MALE' },
+        { categoryName: 'U18', ageMax: 17 },
+      );
+      expect(result.success).toEqual(true);
+      expect(result.addedEntriesCount).toEqual(1);
+    });
+
+    it('rejects a person with only birthYear who is too old, reporting birthYear in details', () => {
+      // 2024 − 2000 = 24, outside U18
+      const result: any = setup(
+        { birthYear: 2000, standardGivenName: 'Year', standardFamilyName: 'Old', sex: 'MALE' },
+        { categoryName: 'U18', ageMax: 17 },
+      );
+      expect(result.error).toEqual(INVALID_PARTICIPANT_IDS);
+      const reason = result.context.categoryRejections[0].rejectionReasons[0];
+      expect(reason.type).toEqual('age');
+      expect(reason.details.birthYear).toEqual(2000);
+      expect(reason.details.birthDate).toBeUndefined();
+      expect(reason.details.ageAtStart).toEqual(24);
+    });
+
+    it('birthDate is authoritative when both birthDate and birthYear are present', () => {
+      // birthYear 2010 would pass, but birthDate 2000 (age 24) must win → rejected
+      const result: any = setup(
+        { birthDate: '2000-01-01', birthYear: 2010, standardGivenName: 'Both', standardFamilyName: 'Set', sex: 'MALE' },
+        { categoryName: 'U18', ageMax: 17 },
+      );
+      expect(result.error).toEqual(INVALID_PARTICIPANT_IDS);
+      const reason = result.context.categoryRejections[0].rejectionReasons[0];
+      expect(reason.details.birthDate).toEqual('2000-01-01');
+      expect(reason.details.birthYear).toBeUndefined();
+    });
+
+    it('rejects when both birthDate and birthYear are missing', () => {
+      const result: any = setup(
+        { standardGivenName: 'No', standardFamilyName: 'Dob', sex: 'MALE' },
+        { categoryName: 'U18', ageMax: 17 },
+      );
+      expect(result.error).toEqual(INVALID_PARTICIPANT_IDS);
+      expect(result.context.categoryRejections[0].rejectionReasons[0].reason).toContain(
+        'Missing birthDate or birthYear',
+      );
     });
   });
 });

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -1165,6 +1165,11 @@ export interface Person {
   addresses?: Address[];
   biographicalInformation?: BiographicalInformation;
   birthDate?: string;
+  /** Year-precision date of birth (CODES). Use when only the birth year is
+   *  known (common in federation junior data). `birthDate` is authoritative when
+   *  both are present; age/category eligibility falls back to this via the
+   *  calendar-year convention (age-in-year = year − birthYear). */
+  birthYear?: number;
   contacts?: Contact[];
   createdAt?: Date | string;
   extensions?: Extension[];


### PR DESCRIPTION
Optional year-precision DOB field. Federation junior data routinely has only the birth year, which `birthDate` (JSON-Schema date) can't represent. The two age-eligibility gates (`addEventEntries`/`categoryValidation` and `modifyEvent`) fall back to `birthYear` when `birthDate` is absent, using the calendar-year convention (age = year − birthYear); `birthDate` authoritative when both present. CODES superset field (Person had additionalProperties:false → schema add required; also legitimizes the birthYear the CTS adapter already emits). +4 tests; Docusaurus updated. Full suite 9476 green.