### PR TITLE
feat!: CODES Phase 2 — promote matchUp.schedule.* to first-class

### DIFF
--- a/src/acquire/firstClassOrTimeItem.ts
+++ b/src/acquire/firstClassOrTimeItem.ts
@@ -1,0 +1,31 @@
+import { getTimeItem } from '@Query/base/timeItems';
+
+type FirstClassOrTimeItemArgs = {
+  element: any;
+  scheduleObject?: string;
+  attribute: string;
+  itemType: string;
+};
+
+/**
+ * Read helper for the CODES schemaWriteMode transition (timeItems variant).
+ *
+ * Returns the first-class schedule attribute when defined, otherwise falls
+ * back to the latest timeItem with the matching `itemType`. Used everywhere
+ * a former schedule-timeItem is read so that records written in any mode
+ * (NATIVE, DUAL, LEGACY) read identically.
+ *
+ * Mirrors {@link firstClassOrExtension} for the timeItems plumbing.
+ */
+export function firstClassOrTimeItem({
+  element,
+  scheduleObject = 'schedule',
+  attribute,
+  itemType,
+}: FirstClassOrTimeItemArgs) {
+  const firstClass = element?.[scheduleObject]?.[attribute];
+  if (firstClass !== undefined) return firstClass;
+  if (!Array.isArray(element?.timeItems)) return undefined;
+  const { timeItem } = getTimeItem({ element, itemType });
+  return timeItem?.itemValue;
+}

--- a/src/assemblies/generators/scheduling/utils/generateBookings.ts
+++ b/src/assemblies/generators/scheduling/utils/generateBookings.ts
@@ -66,11 +66,12 @@ export function generateBookings({
 
   dateScheduledMatchUps ??= matchUps?.filter((matchUp) => {
     const schedule = matchUp.schedule;
-    return hasSchedule({ schedule }) && (!scheduleDate || matchUp.schedule.scheduledDate === scheduleDate);
+    return hasSchedule({ schedule }) && (!scheduleDate || schedule?.scheduledDate === scheduleDate);
   });
 
   const relevantMatchUps = dateScheduledMatchUps?.filter(
-    (matchUp) => (!venueIds.length || venueIds.includes(matchUp.schedule.venueId)) && matchUp.matchUpStatus !== BYE,
+    (matchUp) =>
+      (!venueIds.length || venueIds.includes(matchUp.schedule?.venueId ?? '')) && matchUp.matchUpStatus !== BYE,
   );
 
   const bookings = relevantMatchUps
@@ -86,8 +87,8 @@ export function generateBookings({
         timingDetails,
         eventType,
       });
-      const { courtId, venueId } = schedule;
-      const startTime = extractTime(schedule.scheduledTime);
+      const { courtId, venueId } = schedule ?? {};
+      const startTime = extractTime(schedule?.scheduledTime);
       const endTime = addMinutesToTimeString(startTime, averageMinutes);
       return {
         recoveryMinutes,

--- a/src/mutate/matchUps/schedule/allocateTeamMatchUpCourts.ts
+++ b/src/mutate/matchUps/schedule/allocateTeamMatchUpCourts.ts
@@ -1,4 +1,4 @@
-import { addMatchUpTimeItem } from '@Mutate/timeItems/matchUps/matchUpTimeItems';
+import { setMatchUpFirstClassOrTimeItem } from '@Mutate/timeItems/matchUps/setMatchUpFirstClassOrTimeItem';
 import { getVenuesAndCourts } from '@Query/venues/venuesAndCourtsGetter';
 import { findDrawMatchUp } from '@Acquire/findDrawMatchUp';
 
@@ -70,19 +70,16 @@ export function allocateTeamMatchUpCourts({
     }));
   }
 
-  const timeItem = {
+  return setMatchUpFirstClassOrTimeItem({
+    duplicateValues: false,
+    attribute: 'allocatedCourts',
     itemType: ALLOCATE_COURTS,
     itemDate: courtDayDate,
-    itemValue,
-  };
-
-  return addMatchUpTimeItem({
-    duplicateValues: false,
+    value: itemValue,
     removePriorValues,
     tournamentRecord,
     drawDefinition,
     disableNotice,
     matchUpId,
-    timeItem,
   });
 }

--- a/src/mutate/matchUps/schedule/assignMatchUpCourt.ts
+++ b/src/mutate/matchUps/schedule/assignMatchUpCourt.ts
@@ -1,4 +1,4 @@
-import { addMatchUpTimeItem } from '@Mutate/timeItems/matchUps/matchUpTimeItems';
+import { setMatchUpFirstClassOrTimeItem } from '@Mutate/timeItems/matchUps/setMatchUpFirstClassOrTimeItem';
 import { assignMatchUpVenue } from '@Mutate/matchUps/schedule/assignMatchUpVenue';
 import { findCourt } from '@Query/venues/findCourt';
 
@@ -49,19 +49,16 @@ export function assignMatchUpCourt({
     });
   }
 
-  const timeItem = {
+  return setMatchUpFirstClassOrTimeItem({
+    duplicateValues: false,
+    attribute: 'courtId',
     itemType: ASSIGN_COURT,
     itemDate: courtDayDate,
-    itemValue: courtId,
-  };
-
-  return addMatchUpTimeItem({
-    duplicateValues: false,
+    value: courtId,
     removePriorValues,
     tournamentRecord,
     drawDefinition,
     disableNotice,
     matchUpId,
-    timeItem,
   });
 }

--- a/src/mutate/matchUps/schedule/assignMatchUpVenue.ts
+++ b/src/mutate/matchUps/schedule/assignMatchUpVenue.ts
@@ -1,4 +1,4 @@
-import { addMatchUpTimeItem } from '@Mutate/timeItems/matchUps/matchUpTimeItems';
+import { setMatchUpFirstClassOrTimeItem } from '@Mutate/timeItems/matchUps/setMatchUpFirstClassOrTimeItem';
 import { findVenue } from '@Query/venues/findVenue';
 
 // constants and types
@@ -36,18 +36,15 @@ export function assignMatchUpVenue({
     if (result.error) return result;
   }
 
-  const timeItem = {
-    itemType: ASSIGN_VENUE,
-    itemValue: venueId,
-  };
-
-  return addMatchUpTimeItem({
+  return setMatchUpFirstClassOrTimeItem({
     duplicateValues: false,
+    attribute: 'venueId',
+    itemType: ASSIGN_VENUE,
+    value: venueId,
     removePriorValues,
     tournamentRecord,
     drawDefinition,
     disableNotice,
     matchUpId,
-    timeItem,
   });
 }

--- a/src/mutate/matchUps/schedule/clearMatchUpSchedule.ts
+++ b/src/mutate/matchUps/schedule/clearMatchUpSchedule.ts
@@ -8,14 +8,35 @@ import { SUCCESS } from '@Constants/resultConstants';
 import {
   ALLOCATE_COURTS,
   ASSIGN_COURT,
+  ASSIGN_OFFICIAL,
   ASSIGN_VENUE,
+  COURT_ANNOTATION,
+  COURT_ORDER,
   END_TIME,
+  HOME_PARTICIPANT_ID,
   RESUME_TIME,
   SCHEDULED_DATE,
   SCHEDULED_TIME,
   START_TIME,
   STOP_TIME,
+  TIME_MODIFIERS,
 } from '@Constants/timeItemConstants';
+
+// Map of legacy itemType → first-class MatchUpSchedule attribute for the
+// CODES promotion. clearMatchUpSchedule must wipe BOTH surfaces so that
+// records written in any schemaWriteMode are cleanly reset.
+const ITEM_TYPE_TO_SCHEDULE_ATTR: Record<string, string> = {
+  [ALLOCATE_COURTS]: 'allocatedCourts',
+  [ASSIGN_COURT]: 'courtId',
+  [ASSIGN_OFFICIAL]: 'official',
+  [ASSIGN_VENUE]: 'venueId',
+  [COURT_ANNOTATION]: 'courtAnnotation',
+  [COURT_ORDER]: 'courtOrder',
+  [HOME_PARTICIPANT_ID]: 'homeParticipantId',
+  [SCHEDULED_DATE]: 'scheduledDate',
+  [SCHEDULED_TIME]: 'scheduledTime',
+  [TIME_MODIFIERS]: 'timeModifiers',
+};
 
 export function clearMatchUpSchedule({
   scheduleAttributes = [
@@ -52,6 +73,16 @@ export function clearMatchUpSchedule({
     (timeItem) => timeItem?.itemType && !scheduleAttributes.includes(timeItem?.itemType),
   );
   matchUp.timeItems = newTimeItems;
+
+  // CODES: also strip any first-class `matchUp.schedule.*` attributes
+  // whose itemType is being cleared.
+  if (matchUp.schedule) {
+    for (const itemType of scheduleAttributes) {
+      const attr = ITEM_TYPE_TO_SCHEDULE_ATTR[itemType];
+      if (attr) delete matchUp.schedule[attr];
+    }
+    if (Object.keys(matchUp.schedule).length === 0) delete matchUp.schedule;
+  }
 
   modifyMatchUpNotice({
     tournamentId: tournamentRecord.tournamentId,

--- a/src/mutate/matchUps/schedule/clearScheduledMatchUps.ts
+++ b/src/mutate/matchUps/schedule/clearScheduledMatchUps.ts
@@ -101,7 +101,7 @@ function clearSchedules({
     if (
       (!matchUpStatus || !ignoreMatchUpStatuses.includes(matchUpStatus)) &&
       hasSchedule({ schedule, scheduleAttributes }) &&
-      (!venueIds?.length || venueIds.includes(schedule.venueId))
+      (!venueIds?.length || venueIds.includes(schedule?.venueId ?? ''))
     ) {
       if (!drawMatchUpIds[drawId]) drawMatchUpIds[drawId] = [];
       drawMatchUpIds[drawId].push(matchUpId);
@@ -121,9 +121,15 @@ function clearSchedules({
       matchUp.timeItems = (matchUp.timeItems ?? []).filter((timeItem) => {
         const preserve =
           timeItem?.itemType &&
-          ![ALLOCATE_COURTS, ASSIGN_COURT, ASSIGN_VENUE, COURT_ANNOTATION, COURT_ORDER, SCHEDULED_DATE, SCHEDULED_TIME].includes(
-            timeItem?.itemType,
-          );
+          ![
+            ALLOCATE_COURTS,
+            ASSIGN_COURT,
+            ASSIGN_VENUE,
+            COURT_ANNOTATION,
+            COURT_ORDER,
+            SCHEDULED_DATE,
+            SCHEDULED_TIME,
+          ].includes(timeItem?.itemType);
         if (!preserve) modified = true;
         return preserve;
       });

--- a/src/mutate/matchUps/schedule/scheduleItems/addMatchUpScheduledDate.ts
+++ b/src/mutate/matchUps/schedule/scheduleItems/addMatchUpScheduledDate.ts
@@ -1,4 +1,4 @@
-import { addMatchUpTimeItem } from '@Mutate/timeItems/matchUps/matchUpTimeItems';
+import { setMatchUpFirstClassOrTimeItem } from '@Mutate/timeItems/matchUps/setMatchUpFirstClassOrTimeItem';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { dateValidation } from '@Validators/regex';
 import { extractDate } from '@Tools/dateTime';
@@ -37,18 +37,15 @@ export function addMatchUpScheduledDate({
       });
   }
 
-  const timeItem = {
-    itemValue: scheduledDate,
-    itemType: SCHEDULED_DATE,
-  };
-
-  return addMatchUpTimeItem({
+  return setMatchUpFirstClassOrTimeItem({
     duplicateValues: false,
+    attribute: 'scheduledDate',
+    itemType: SCHEDULED_DATE,
+    value: scheduledDate,
     removePriorValues,
     tournamentRecord,
     drawDefinition,
     disableNotice,
     matchUpId,
-    timeItem,
   });
 }

--- a/src/mutate/matchUps/schedule/scheduleItems/scheduleItems.ts
+++ b/src/mutate/matchUps/schedule/scheduleItems/scheduleItems.ts
@@ -1,5 +1,6 @@
 import { convertTime, extractDate, extractTime, formatDate, getIsoDateString, validTimeValue } from '@Tools/dateTime';
 import { setMatchUpHomeParticipantId } from '@Mutate/matchUps/schedule/scheduleItems/setMatchUpHomeParticipantId';
+import { setMatchUpFirstClassOrTimeItem } from '@Mutate/timeItems/matchUps/setMatchUpFirstClassOrTimeItem';
 import { addMatchUpScheduledTime, addMatchUpTimeModifiers } from '@Mutate/matchUps/schedule/scheduledTime';
 import { addMatchUpScheduledDate } from '@Mutate/matchUps/schedule/scheduleItems/addMatchUpScheduledDate';
 import { allocateTeamMatchUpCourts } from '@Mutate/matchUps/schedule/allocateTeamMatchUpCourts';
@@ -29,7 +30,7 @@ import {
   COURT_ORDER,
   COURT_ANNOTATION,
 } from '@Constants/timeItemConstants';
-import { DrawDefinition, Event, TimeItem } from '@Types/tournamentTypes';
+import { DrawDefinition, Event } from '@Types/tournamentTypes';
 import { OBJECT, OF_TYPE } from '@Constants/attributeConstants';
 import { AddScheduleAttributeArgs } from '@Types/factoryTypes';
 import { INDIVIDUAL } from '@Constants/participantConstants';
@@ -495,19 +496,17 @@ export function addMatchUpCourtOrder({
     return { error: INVALID_VALUES, info: 'courtOrder must be numeric' };
 
   const itemValue = courtOrder && ensureInt(courtOrder);
-  const timeItem = {
-    itemType: COURT_ORDER,
-    itemValue,
-  };
 
-  return addMatchUpTimeItem({
+  return setMatchUpFirstClassOrTimeItem({
     duplicateValues: false,
+    attribute: 'courtOrder',
+    itemType: COURT_ORDER,
+    value: itemValue,
     removePriorValues,
     tournamentRecord,
     drawDefinition,
     disableNotice,
     matchUpId,
-    timeItem,
   });
 }
 
@@ -523,19 +522,17 @@ export function addMatchUpCourtAnnotation({
 
   // undefined or empty string clears the annotation
   const itemValue = courtAnnotation || undefined;
-  const timeItem = {
-    itemType: COURT_ANNOTATION,
-    itemValue,
-  };
 
-  return addMatchUpTimeItem({
+  return setMatchUpFirstClassOrTimeItem({
     duplicateValues: false,
+    attribute: 'courtAnnotation',
+    itemType: COURT_ANNOTATION,
+    value: itemValue,
     removePriorValues,
     tournamentRecord,
     drawDefinition,
     disableNotice,
     matchUpId,
-    timeItem,
   });
 }
 
@@ -573,20 +570,17 @@ export function addMatchUpOfficial({
     if (!participant) return { error: PARTICIPANT_NOT_FOUND };
   }
 
-  const timeItem: TimeItem = {
-    itemType: 'SCHEDULE.ASSIGNMENT.OFFICIAL',
-    itemValue: participantId,
-  };
-  if (officialType) timeItem.itemSubTypes = [officialType];
-
-  return addMatchUpTimeItem({
+  return setMatchUpFirstClassOrTimeItem({
     duplicateValues: false,
+    attribute: 'official',
+    itemType: 'SCHEDULE.ASSIGNMENT.OFFICIAL',
+    itemSubTypes: officialType ? [officialType] : undefined,
+    value: participantId,
     removePriorValues,
     tournamentRecord,
     drawDefinition,
     disableNotice,
     matchUpId,
-    timeItem,
   });
 }
 

--- a/src/mutate/matchUps/schedule/scheduleItems/setMatchUpHomeParticipantId.ts
+++ b/src/mutate/matchUps/schedule/scheduleItems/setMatchUpHomeParticipantId.ts
@@ -1,6 +1,6 @@
+import { setMatchUpFirstClassOrTimeItem } from '@Mutate/timeItems/matchUps/setMatchUpFirstClassOrTimeItem';
 import { checkRequiredParameters } from '@Helpers/parameters/checkRequiredParameters';
 import { resolveFromParameters } from '@Helpers/parameters/resolveFromParameters';
-import { addMatchUpTimeItem } from '@Mutate/timeItems/matchUps/matchUpTimeItems';
 
 // constants and types
 import { INVALID_PARTICIPANT_ID, MISSING_PARTICIPANT_ID } from '@Constants/errorConditionConstants';
@@ -34,18 +34,15 @@ export function setMatchUpHomeParticipantId(
 
   const { disableNotice, homeParticipantId, removePriorValues, tournamentRecord, drawDefinition, matchUpId } = params;
 
-  const timeItem = {
-    itemType: HOME_PARTICIPANT_ID,
-    itemValue: homeParticipantId,
-  };
-
-  return addMatchUpTimeItem({
+  return setMatchUpFirstClassOrTimeItem({
     duplicateValues: false,
+    attribute: 'homeParticipantId',
+    itemType: HOME_PARTICIPANT_ID,
+    value: homeParticipantId,
     removePriorValues,
     tournamentRecord,
     drawDefinition,
     disableNotice,
     matchUpId,
-    timeItem,
   });
 }

--- a/src/mutate/matchUps/schedule/scheduledTime.ts
+++ b/src/mutate/matchUps/schedule/scheduledTime.ts
@@ -1,4 +1,4 @@
-import { addMatchUpTimeItem } from '@Mutate/timeItems/matchUps/matchUpTimeItems';
+import { setMatchUpFirstClassOrTimeItem } from '@Mutate/timeItems/matchUps/setMatchUpFirstClassOrTimeItem';
 import { convertTime, extractDate, validTimeValue } from '@Tools/dateTime';
 import { scheduledMatchUpDate } from '@Query/matchUp/scheduledMatchUpDate';
 import { matchUpTimeModifiers } from '@Query/matchUp/timeModifiers';
@@ -71,20 +71,17 @@ export function addMatchUpScheduledTime(params: AddMatchUpScheduledTimeArgs) {
 
   // All times stored as military time
   const militaryTime = convertTime(scheduledTime, true, keepDate);
-  const itemValue = militaryTime;
-  const timeItem = {
-    itemType: SCHEDULED_TIME,
-    itemValue,
-  };
 
-  return addMatchUpTimeItem({
+  return setMatchUpFirstClassOrTimeItem({
     duplicateValues: false,
+    attribute: 'scheduledTime',
+    itemType: SCHEDULED_TIME,
+    value: militaryTime,
     removePriorValues,
     tournamentRecord,
     drawDefinition,
     disableNotice,
     matchUpId,
-    timeItem,
   });
 }
 
@@ -141,18 +138,15 @@ export function addMatchUpTimeModifiers({
   // undefined value when array is empty;
   const itemValue = !timeModifiers?.length ? undefined : [...toBeAdded, ...existingTimeModifiers];
 
-  const timeItem = {
-    itemType: TIME_MODIFIERS,
-    itemValue,
-  };
-
-  return addMatchUpTimeItem({
+  return setMatchUpFirstClassOrTimeItem({
     duplicateValues: false,
+    attribute: 'timeModifiers',
+    itemType: TIME_MODIFIERS,
+    value: itemValue,
     removePriorValues,
     tournamentRecord,
     drawDefinition,
     disableNotice,
     matchUpId,
-    timeItem,
   });
 }

--- a/src/mutate/matchUps/schedule/schedulers/proScheduler/proAutoSchedule.ts
+++ b/src/mutate/matchUps/schedule/schedulers/proScheduler/proAutoSchedule.ts
@@ -146,6 +146,7 @@ export function proAutoSchedule({
 
       if (verdict.canPlace && matchUp) {
         const court = row.availableCourts.shift();
+        matchUp.schedule ??= {};
         Object.assign(matchUp.schedule, court.schedule);
         Object.assign(court, matchUp);
         scheduled.push(matchUp);

--- a/src/mutate/matchUps/schedule/schedulers/proScheduler/proConflicts.ts
+++ b/src/mutate/matchUps/schedule/schedulers/proScheduler/proConflicts.ts
@@ -56,7 +56,9 @@ export function proConflicts({
 
   const sortedFiltered = filteredRows.flat().filter(Boolean).sort(matchUpSort);
 
-  sortedFiltered.forEach(({ schedule }) => delete schedule[SCHEDULE_STATE]);
+  sortedFiltered.forEach(({ schedule }) => {
+    if (schedule) delete schedule[SCHEDULE_STATE];
+  });
 
   const drawIds = unique(matchUps.map(({ drawId }) => drawId));
   const depsResult = getMatchUpDependencies({
@@ -82,7 +84,7 @@ export function proConflicts({
         const { matchUpId, winnerMatchUpId, loserMatchUpId, schedule, sides, potentialParticipants } = matchUp;
         const courtId = schedule?.courtId;
         rowIndices[matchUpId] = rowIndex;
-        courtIssues[courtId] = [];
+        if (courtId) courtIssues[courtId] = [];
 
         profile.matchUpIds.push(matchUpId);
         mappedMatchUps[matchUpId] = matchUp;
@@ -345,7 +347,12 @@ export function proConflicts({
         if (matchUpIdSet.size > 1) {
           const matchUpIds = [...matchUpIdSet];
           for (const matchUpId of matchUpIds) {
-            annotate(matchUpId, SCHEDULE_WARNING, CONFLICT_POTENTIAL_PARTICIPANTS, matchUpIds.filter((id) => id !== matchUpId));
+            annotate(
+              matchUpId,
+              SCHEDULE_WARNING,
+              CONFLICT_POTENTIAL_PARTICIPANTS,
+              matchUpIds.filter((id) => id !== matchUpId),
+            );
           }
         }
       }
@@ -360,7 +367,12 @@ export function proConflicts({
           if (previousDeepMap[participantId]) {
             const involvedMatchUpIds = [...new Set([...currentMatchUpIdSet, ...previousDeepMap[participantId]])];
             for (const matchUpId of involvedMatchUpIds) {
-              annotate(matchUpId, SCHEDULE_WARNING, CONFLICT_POTENTIAL_PARTICIPANTS, involvedMatchUpIds.filter((id) => id !== matchUpId));
+              annotate(
+                matchUpId,
+                SCHEDULE_WARNING,
+                CONFLICT_POTENTIAL_PARTICIPANTS,
+                involvedMatchUpIds.filter((id) => id !== matchUpId),
+              );
             }
           }
         }

--- a/src/mutate/matchUps/schedule/schedulers/processAlreadyScheduledMatchUps.ts
+++ b/src/mutate/matchUps/schedule/schedulers/processAlreadyScheduledMatchUps.ts
@@ -55,7 +55,9 @@ export function processAlreadyScheduledMatchUps({
           matchUpId: matchUp.matchUpId,
         });
       return (
-        !isByeMatchUp && hasSchedule({ schedule }) && (!scheduleDate || matchUp.schedule.scheduledDate === scheduleDate)
+        !isByeMatchUp &&
+        hasSchedule({ schedule }) &&
+        (!scheduleDate || matchUp.schedule?.scheduledDate === scheduleDate)
       );
     });
 

--- a/src/mutate/timeItems/matchUps/setMatchUpFirstClassOrTimeItem.ts
+++ b/src/mutate/timeItems/matchUps/setMatchUpFirstClassOrTimeItem.ts
@@ -1,0 +1,75 @@
+import { setFirstClassOrTimeItem } from '@Mutate/timeItems/setFirstClassOrTimeItem';
+import { modifyMatchUpNotice } from '@Mutate/notifications/drawNotifications';
+import { findDrawMatchUp } from '@Acquire/findDrawMatchUp';
+
+// constants and types
+import { DrawDefinition, Event, Tournament } from '@Types/tournamentTypes';
+import { MATCHUP_NOT_FOUND } from '@Constants/errorConditionConstants';
+import { ResultType } from '@Types/factoryTypes';
+
+type SetMatchUpFirstClassOrTimeItemArgs = {
+  tournamentRecord?: Tournament;
+  drawDefinition: DrawDefinition;
+  removePriorValues?: boolean;
+  duplicateValues?: boolean;
+  disableNotice?: boolean;
+  itemSubTypes?: string[];
+  itemDate?: string;
+  matchUpId: string;
+  attribute: string;
+  itemType: string;
+  value: any;
+  event?: Event;
+};
+
+/**
+ * MatchUp-scoped wrapper around `setFirstClassOrTimeItem` that mirrors the
+ * existing `addMatchUpTimeItem` surface: it resolves the matchUp via
+ * `findDrawMatchUp`, delegates to the mode-aware helper, then emits the
+ * standard `modifyMatchUpNotice`.
+ *
+ * Drop-in replacement for `addMatchUpTimeItem` in factory writers that
+ * promote a schedule timeItem to a first-class `matchUp.schedule.*`
+ * attribute in CODES.
+ */
+export function setMatchUpFirstClassOrTimeItem({
+  tournamentRecord,
+  removePriorValues,
+  duplicateValues,
+  drawDefinition,
+  disableNotice,
+  itemSubTypes,
+  itemDate,
+  matchUpId,
+  attribute,
+  itemType,
+  value,
+  event,
+}: SetMatchUpFirstClassOrTimeItemArgs): ResultType {
+  const { matchUp } = findDrawMatchUp({ drawDefinition, event, matchUpId });
+  if (!matchUp) return { error: MATCHUP_NOT_FOUND };
+
+  const result = setFirstClassOrTimeItem({
+    element: matchUp,
+    scheduleObject: 'schedule',
+    removePriorValues,
+    duplicateValues,
+    itemSubTypes,
+    itemDate,
+    attribute,
+    itemType,
+    value,
+  });
+  if (result.error) return result;
+
+  if (!disableNotice) {
+    modifyMatchUpNotice({
+      tournamentId: tournamentRecord?.tournamentId,
+      eventId: event?.eventId,
+      context: 'setFirstClassOrTimeItem',
+      drawDefinition,
+      matchUp,
+    });
+  }
+  return result;
+}

--- a/src/mutate/timeItems/setFirstClassOrTimeItem.ts
+++ b/src/mutate/timeItems/setFirstClassOrTimeItem.ts
@@ -1,0 +1,115 @@
+import { writeLegacyEnabled, writeNativeEnabled } from '@Global/state/globalState';
+import { decorateResult } from '@Functions/global/decorateResult';
+import { addTimeItem } from './addTimeItem';
+
+// constants and types
+import { ErrorType, INVALID_VALUES, MISSING_VALUE } from '@Constants/errorConditionConstants';
+import { SUCCESS } from '@Constants/resultConstants';
+
+type SetFirstClassOrTimeItemArgs = {
+  element: any;
+  scheduleObject?: string;
+  attribute: string;
+  itemType: string;
+  value: any;
+  itemSubTypes?: string[];
+  itemDate?: string;
+  removePriorValues?: boolean;
+  duplicateValues?: boolean;
+};
+
+function writeNativeFirstClass(element: any, scheduleObject: string, attribute: string, value: any) {
+  if (value === undefined || value === null) {
+    if (element[scheduleObject]) delete element[scheduleObject][attribute];
+    return;
+  }
+  if (!element[scheduleObject]) element[scheduleObject] = {};
+  element[scheduleObject][attribute] = value;
+}
+
+function stripTimeItemsByType(element: any, itemType: string) {
+  if (Array.isArray(element.timeItems)) {
+    element.timeItems = element.timeItems.filter((ti: any) => ti?.itemType !== itemType);
+  }
+}
+
+function appendLegacyTimeItem(args: {
+  element: any;
+  itemType: string;
+  value: any;
+  itemSubTypes?: string[];
+  itemDate?: string;
+  removePriorValues?: boolean;
+  duplicateValues?: boolean;
+}) {
+  const { element, itemType, value, itemSubTypes, itemDate, removePriorValues, duplicateValues } = args;
+  const timeItem: any = { itemType, itemValue: value };
+  if (itemSubTypes?.length) timeItem.itemSubTypes = itemSubTypes;
+  if (itemDate) timeItem.itemDate = itemDate;
+  return addTimeItem({ element, timeItem, removePriorValues, duplicateValues });
+}
+
+function validateParams(params?: SetFirstClassOrTimeItemArgs): { error?: ErrorType } | null {
+  if (typeof params !== 'object') return { error: MISSING_VALUE };
+  if (!params.element || typeof params.element !== 'object') return { error: INVALID_VALUES };
+  if (typeof params.attribute !== 'string' || !params.attribute) return { error: INVALID_VALUES };
+  if (typeof params.itemType !== 'string' || !params.itemType) return { error: INVALID_VALUES };
+  return null;
+}
+
+/**
+ * Write helper for promoting schedule-related timeItems to first-class
+ * attributes on a parent object (typically `matchUp.schedule.*`).
+ *
+ * Branches on the current `schemaWriteMode`:
+ *
+ * - NATIVE: write `element[scheduleObject][attribute] = value`; strip any
+ *   stale timeItem with the matching `itemType` so reads stay consistent.
+ *   When `value` is `undefined`, also remove the first-class field.
+ * - DUAL: write the first-class attribute AND keep the legacy timeItem
+ *   append (back-compat for consumers reading `timeItems[]` directly).
+ * - LEGACY: only call `addTimeItem` — preserves pre-CODES behavior.
+ *
+ * Use ONLY for schedule-style itemTypes whose semantic is last-write-wins
+ * (SCHEDULED_DATE, SCHEDULED_TIME, ASSIGN_COURT, ASSIGN_VENUE, COURT_ORDER,
+ * COURT_ANNOTATION, ALLOCATE_COURTS, TIME_MODIFIERS, HOME_PARTICIPANT_ID,
+ * ASSIGN_OFFICIAL). Lifecycle items (`START_TIME / STOP_TIME / RESUME_TIME
+ * / END_TIME`) MUST keep writing through `addTimeItem` directly because
+ * `matchUpDuration()` consumes the ordered history.
+ *
+ * Read with {@link firstClassOrTimeItem} for symmetric semantics.
+ */
+export function setFirstClassOrTimeItem(params?: SetFirstClassOrTimeItemArgs): {
+  success?: boolean;
+  error?: ErrorType;
+} {
+  const stack = 'setFirstClassOrTimeItem';
+  const validation = validateParams(params);
+  if (validation) return decorateResult({ result: validation, stack });
+
+  const { element, scheduleObject = 'schedule', attribute, itemType, value } = params as SetFirstClassOrTimeItemArgs;
+
+  if (writeNativeEnabled()) {
+    writeNativeFirstClass(element, scheduleObject, attribute, value);
+    // NATIVE invariant: schedule timeItems do not coexist with their first-class
+    // attribute. Strip any stale entries with this itemType.
+    stripTimeItemsByType(element, itemType);
+  }
+
+  if (!writeLegacyEnabled()) return { ...SUCCESS };
+
+  // LEGACY (or DUAL legacy branch): always delegate to addTimeItem so that
+  // its `removePriorValues` / `duplicateValues` semantics — including the
+  // undefined-value-push behavior — match pre-CODES exactly.
+  const result = appendLegacyTimeItem({
+    element,
+    itemType,
+    value,
+    itemSubTypes: params?.itemSubTypes,
+    itemDate: params?.itemDate,
+    removePriorValues: params?.removePriorValues,
+    duplicateValues: params?.duplicateValues,
+  });
+  if (result.error) return decorateResult({ result, stack });
+  return { ...SUCCESS };
+}

--- a/src/query/matchUp/getMatchUpScheduleDetails.ts
+++ b/src/query/matchUp/getMatchUpScheduleDetails.ts
@@ -95,8 +95,7 @@ export function getMatchUpScheduleDetails(params: GetMatchUpScheduleDetailsArgs)
   const { endTime } = matchUpEndTime({ matchUp });
 
   const { eventIds, drawIds } = scheduleVisibilityFilters ?? {};
-  const isVisible =
-    (!eventIds || eventIds.includes(matchUp.eventId)) && (!drawIds || drawIds.includes(matchUp.drawId));
+  const isVisible = (!eventIds || eventIds.includes(matchUp.eventId)) && (!drawIds || drawIds.includes(matchUp.drawId));
 
   let schedule = isVisible
     ? buildFullSchedule({
@@ -150,7 +149,18 @@ export function getMatchUpScheduleDetails(params: GetMatchUpScheduleDetailsArgs)
   return { schedule, endDate };
 }
 
-function buildFullSchedule({ tournamentRecord, scheduleTiming, afterRecoveryTimes, matchUpFormat, matchUpType, matchUp, endTime, startTime, milliseconds, time }) {
+function buildFullSchedule({
+  tournamentRecord,
+  scheduleTiming,
+  afterRecoveryTimes,
+  matchUpFormat,
+  matchUpType,
+  matchUp,
+  endTime,
+  startTime,
+  milliseconds,
+  time,
+}) {
   const getTimeStamp = (item) => (item.createdAt ? new Date(item.createdAt).getTime() : 0);
 
   const timeItemMap = new Map();
@@ -158,16 +168,21 @@ function buildFullSchedule({ tournamentRecord, scheduleTiming, afterRecoveryTime
   for (const timeItem of sortedTimeItems) {
     timeItemMap.set(timeItem.itemType, timeItem.itemValue);
   }
-  const homeParticipantId = timeItemMap.get(HOME_PARTICIPANT_ID);
-  const courtAnnotation = timeItemMap.get(COURT_ANNOTATION);
-  const allocatedCourts = timeItemMap.get(ALLOCATE_COURTS);
-  const scheduledTime = timeItemMap.get(SCHEDULED_TIME);
-  const timeModifiers = timeItemMap.get(TIME_MODIFIERS);
-  let scheduledDate = timeItemMap.get(SCHEDULED_DATE);
-  const official = timeItemMap.get(ASSIGN_OFFICIAL);
-  const courtOrder = timeItemMap.get(COURT_ORDER);
-  const venueId = timeItemMap.get(ASSIGN_VENUE);
-  const courtId = timeItemMap.get(ASSIGN_COURT);
+
+  // CODES: prefer first-class `matchUp.schedule.*` attributes; fall back to
+  // the legacy timeItem entry. Records written in NATIVE / DUAL / LEGACY all
+  // hydrate to the same shape.
+  const firstClass = matchUp.schedule ?? {};
+  const homeParticipantId = firstClass.homeParticipantId ?? timeItemMap.get(HOME_PARTICIPANT_ID);
+  const courtAnnotation = firstClass.courtAnnotation ?? timeItemMap.get(COURT_ANNOTATION);
+  const allocatedCourts = firstClass.allocatedCourts ?? timeItemMap.get(ALLOCATE_COURTS);
+  const scheduledTime = firstClass.scheduledTime ?? timeItemMap.get(SCHEDULED_TIME);
+  const timeModifiers = firstClass.timeModifiers ?? timeItemMap.get(TIME_MODIFIERS);
+  let scheduledDate = firstClass.scheduledDate ?? timeItemMap.get(SCHEDULED_DATE);
+  const official = firstClass.official ?? timeItemMap.get(ASSIGN_OFFICIAL);
+  const courtOrder = firstClass.courtOrder ?? timeItemMap.get(COURT_ORDER);
+  const venueId = firstClass.venueId ?? timeItemMap.get(ASSIGN_VENUE);
+  const courtId = firstClass.courtId ?? timeItemMap.get(ASSIGN_COURT);
 
   const recoveryTimes = computeRecoveryTimes({
     scheduleTiming,
@@ -217,7 +232,15 @@ function buildFullSchedule({ tournamentRecord, scheduleTiming, afterRecoveryTime
   });
 }
 
-function computeRecoveryTimes({ scheduleTiming, afterRecoveryTimes, matchUpFormat, matchUpType, matchUp, endTime, scheduledTime }) {
+function computeRecoveryTimes({
+  scheduleTiming,
+  afterRecoveryTimes,
+  matchUpFormat,
+  matchUpType,
+  matchUp,
+  endTime,
+  scheduledTime,
+}) {
   let timeAfterRecovery, averageMinutes, recoveryMinutes, typeChangeRecoveryMinutes, typeChangeTimeAfterRecovery;
 
   const eventType = matchUp.matchUpType ?? matchUpType;

--- a/src/tests/global/matchUpScheduleFirstClass.test.ts
+++ b/src/tests/global/matchUpScheduleFirstClass.test.ts
@@ -1,0 +1,195 @@
+/**
+ * CODES Phase 2 — first-class promotion of schedule-related timeItems
+ * (SCHEDULED_DATE, SCHEDULED_TIME, ASSIGN_COURT, ASSIGN_VENUE, COURT_ORDER,
+ * COURT_ANNOTATION, ALLOCATE_COURTS, TIME_MODIFIERS, HOME_PARTICIPANT_ID,
+ * ASSIGN_OFFICIAL) on matchUps.
+ *
+ * Verifies that the schedule writers behave consistently across NATIVE,
+ * DUAL, and LEGACY modes and that buildFullSchedule reads them
+ * symmetrically through the hydration shim. Lifecycle items
+ * (START_TIME / STOP_TIME / RESUME_TIME / END_TIME) remain as timeItems —
+ * matchUpDuration() depends on the ordered history — and are not exercised
+ * here.
+ *
+ * The existing test fleet keeps its LEGACY assertions via the vitest
+ * setupFiles pin; these tests own the new behavior.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { setSchemaWriteMode } from '@Global/state/globalState';
+import tournamentEngine from '../engines/syncEngine';
+import { getTimeItem } from '@Query/base/timeItems';
+import mocksEngine from '@Assemblies/engines/mock';
+
+// constants and types
+import { DUAL, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
+import { SINGLES } from '@Constants/eventConstants';
+import { ASSIGN_COURT, ASSIGN_VENUE, COURT_ORDER, SCHEDULED_DATE, SCHEDULED_TIME } from '@Constants/timeItemConstants';
+
+function setupSingleMatchUpTournament() {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+    startDate: '2026-01-01',
+    endDate: '2026-01-10',
+    drawProfiles: [{ drawSize: 4, eventType: SINGLES }],
+    venueProfiles: [{ venueName: 'Center', courtsCount: 2 }],
+  });
+  tournamentEngine.setState(tournamentRecord);
+
+  const drawId = tournamentRecord.events[0].drawDefinitions[0].drawId;
+  const { matchUps } = tournamentEngine.allDrawMatchUps({ drawId });
+  const matchUp =
+    matchUps.find((m: any) => m.sides?.every((s: any) => s?.participantId) && m.roundNumber === 1) ??
+    matchUps.find((m: any) => m.roundNumber === 1) ??
+    matchUps[0];
+  return { tournamentRecord, drawId, matchUpId: matchUp.matchUpId };
+}
+
+function rawMatchUp(drawId: string, matchUpId: string) {
+  const { drawDefinition } = tournamentEngine.getEvent({ drawId });
+  for (const structure of drawDefinition.structures) {
+    const match = structure.matchUps?.find((m: any) => m.matchUpId === matchUpId);
+    if (match) return match;
+  }
+  return undefined;
+}
+
+describe.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('matchUp.schedule.* end-to-end (mode=%s)', (mode) => {
+  function assertSurfaces(rawMu: any, attribute: string, itemType: string, expected: any) {
+    const firstClass = rawMu.schedule?.[attribute];
+    const ti = (rawMu.timeItems ?? []).find((t: any) => t?.itemType === itemType);
+    if (mode === NATIVE) {
+      expect(firstClass).toEqual(expected);
+      expect(ti).toBeUndefined();
+    } else if (mode === DUAL) {
+      expect(firstClass).toEqual(expected);
+      expect(ti?.itemValue).toEqual(expected);
+    } else {
+      expect(firstClass).toBeUndefined();
+      expect(ti?.itemValue).toEqual(expected);
+    }
+  }
+
+  it('addMatchUpScheduledDate routes to the correct surface(s)', () => {
+    setSchemaWriteMode(mode);
+    const { drawId, matchUpId } = setupSingleMatchUpTournament();
+
+    const r = tournamentEngine.addMatchUpScheduledDate({ drawId, matchUpId, scheduledDate: '2026-01-05' });
+    expect(r.success).toEqual(true);
+    assertSurfaces(rawMatchUp(drawId, matchUpId), 'scheduledDate', SCHEDULED_DATE, '2026-01-05');
+  });
+
+  it('addMatchUpScheduledTime routes correctly', () => {
+    setSchemaWriteMode(mode);
+    const { drawId, matchUpId } = setupSingleMatchUpTournament();
+
+    const r = tournamentEngine.addMatchUpScheduledTime({ drawId, matchUpId, scheduledTime: '14:00' });
+    expect(r.success).toEqual(true);
+
+    const raw = rawMatchUp(drawId, matchUpId);
+    const written =
+      mode === LEGACY
+        ? (raw.timeItems ?? []).find((t: any) => t?.itemType === SCHEDULED_TIME)?.itemValue
+        : raw.schedule?.scheduledTime;
+    expect(written).toContain('14:00');
+  });
+
+  it('addMatchUpCourtOrder routes correctly', () => {
+    setSchemaWriteMode(mode);
+    const { drawId, matchUpId } = setupSingleMatchUpTournament();
+
+    const r = tournamentEngine.addMatchUpCourtOrder({ drawId, matchUpId, courtOrder: 3 });
+    expect(r.success).toEqual(true);
+    assertSurfaces(rawMatchUp(drawId, matchUpId), 'courtOrder', COURT_ORDER, 3);
+  });
+
+  it('assignMatchUpVenue routes correctly', () => {
+    setSchemaWriteMode(mode);
+    const { tournamentRecord, drawId, matchUpId } = setupSingleMatchUpTournament();
+    const venueId = tournamentRecord.venues[0].venueId;
+
+    const r = tournamentEngine.assignMatchUpVenue({ drawId, matchUpId, venueId });
+    expect(r.success).toEqual(true);
+    assertSurfaces(rawMatchUp(drawId, matchUpId), 'venueId', ASSIGN_VENUE, venueId);
+  });
+
+  it('assignMatchUpCourt routes correctly', () => {
+    setSchemaWriteMode(mode);
+    const { tournamentRecord, drawId, matchUpId } = setupSingleMatchUpTournament();
+    const venue = tournamentRecord.venues[0];
+    const courtId = venue.courts[0].courtId;
+
+    const r = tournamentEngine.assignMatchUpCourt({
+      drawId,
+      matchUpId,
+      courtId,
+      courtDayDate: '2026-01-05',
+    });
+    expect(r.success).toEqual(true);
+    assertSurfaces(rawMatchUp(drawId, matchUpId), 'courtId', ASSIGN_COURT, courtId);
+  });
+});
+
+describe('Hydration shim — buildFullSchedule reads first-class then timeItem', () => {
+  it.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])(
+    'mode=%s produces the same hydrated matchUp.schedule.scheduledDate',
+    (mode) => {
+      setSchemaWriteMode(mode);
+      const { drawId, matchUpId } = setupSingleMatchUpTournament();
+
+      tournamentEngine.addMatchUpScheduledDate({ drawId, matchUpId, scheduledDate: '2026-01-05' });
+      tournamentEngine.addMatchUpScheduledTime({ drawId, matchUpId, scheduledTime: '10:30' });
+
+      // hydrate via inContext: true so buildFullSchedule runs over the matchUp
+      const { matchUps } = tournamentEngine.allDrawMatchUps({ drawId, inContext: true });
+      const hydrated = matchUps.find((m: any) => m.matchUpId === matchUpId);
+      expect(hydrated.schedule?.scheduledDate).toEqual('2026-01-05');
+      expect(hydrated.schedule?.scheduledTime).toContain('10:30');
+    },
+  );
+});
+
+describe('NATIVE invariant — schedule timeItems are stripped on first-class writes', () => {
+  it('LEGACY-written timeItem is removed when a NATIVE write replaces it', () => {
+    setSchemaWriteMode(LEGACY);
+    const { drawId, matchUpId } = setupSingleMatchUpTournament();
+    tournamentEngine.addMatchUpScheduledDate({ drawId, matchUpId, scheduledDate: '2026-01-05' });
+
+    // Legacy write produced a timeItem
+    const beforeRaw = rawMatchUp(drawId, matchUpId);
+    expect(getTimeItem({ element: beforeRaw, itemType: SCHEDULED_DATE }).timeItem).toBeDefined();
+    expect(beforeRaw.schedule?.scheduledDate).toBeUndefined();
+
+    // Switch to NATIVE and overwrite
+    setSchemaWriteMode(NATIVE);
+    tournamentEngine.addMatchUpScheduledDate({ drawId, matchUpId, scheduledDate: '2026-01-07' });
+
+    const afterRaw = rawMatchUp(drawId, matchUpId);
+    expect(afterRaw.schedule?.scheduledDate).toEqual('2026-01-07');
+    const remainingScheduledDates = (afterRaw.timeItems ?? []).filter((t: any) => t?.itemType === SCHEDULED_DATE);
+    expect(remainingScheduledDates).toHaveLength(0);
+  });
+});
+
+describe('clearMatchUpSchedule wipes both surfaces', () => {
+  it('removes the timeItem AND the first-class attribute (DUAL fixture)', () => {
+    setSchemaWriteMode(DUAL);
+    const { drawId, matchUpId } = setupSingleMatchUpTournament();
+    tournamentEngine.addMatchUpScheduledDate({ drawId, matchUpId, scheduledDate: '2026-01-05' });
+    tournamentEngine.addMatchUpCourtOrder({ drawId, matchUpId, courtOrder: 2 });
+
+    // DUAL wrote both
+    const before = rawMatchUp(drawId, matchUpId);
+    expect(before.schedule?.scheduledDate).toEqual('2026-01-05');
+    expect(before.schedule?.courtOrder).toEqual(2);
+    expect((before.timeItems ?? []).some((t: any) => t?.itemType === SCHEDULED_DATE)).toEqual(true);
+
+    tournamentEngine.clearMatchUpSchedule({ drawId, matchUpId });
+
+    const after = rawMatchUp(drawId, matchUpId);
+    expect(after.schedule?.scheduledDate).toBeUndefined();
+    // clearMatchUpSchedule's default scheduleAttributes does not include COURT_ORDER,
+    // so the courtOrder write should survive.
+    expect(after.schedule?.courtOrder).toEqual(2);
+    expect((after.timeItems ?? []).some((t: any) => t?.itemType === SCHEDULED_DATE)).toEqual(false);
+  });
+});

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -318,6 +318,32 @@ export interface Interleave {
 
 export type EventTypeUnion = 'SINGLES' | 'DOUBLES' | 'TEAM' | 'HYBRID';
 
+/**
+ * CODES first-class schedule attributes on a matchUp. Each field was
+ * historically stored as a `timeItem` of the corresponding `itemType`
+ * (SCHEDULED_DATE, ASSIGN_COURT, etc.). In CODES the canonical surface is
+ * this object; `timeItems[]` remains the home of `START_TIME / STOP_TIME /
+ * RESUME_TIME / END_TIME` because `matchUpDuration()` walks the full
+ * ordered history. Derived fields like `startTime`, `endTime`,
+ * `milliseconds`, `time`, `venueName`, `courtName`, `isoDateString`, and
+ * the recovery-time calculations remain hydration-time outputs and are
+ * NOT first-class writable.
+ */
+export interface MatchUpSchedule {
+  allocatedCourts?: any[];
+  courtAnnotation?: string;
+  courtId?: string;
+  courtOrder?: number;
+  homeParticipantId?: string;
+  official?: any;
+  scheduledDate?: string;
+  scheduledTime?: string;
+  timeModifiers?: string[];
+  venueId?: string;
+  // derived/hydrated read-only fields (populated by getMatchUpScheduleDetails)
+  [key: string]: any;
+}
+
 export interface MatchUp {
   collectionId?: string;
   collectionPosition?: number;
@@ -342,6 +368,8 @@ export interface MatchUp {
   roundName?: string;
   roundNumber?: number;
   roundPosition?: number;
+  // CODES first-class: previously stored as schedule-related timeItems
+  schedule?: MatchUpSchedule;
   score?: Score;
   sides?: Side[];
   startDate?: string;


### PR DESCRIPTION
## Summary

CODES Phase 2: collapse the 10 canonical schedule-related timeItems onto a new first-class `matchUp.schedule` surface. NATIVE mode is the new default; LEGACY/DUAL preserve back-compat via the `schemaWriteMode` flag introduced in PR #4382.

## Promoted itemTypes → first-class attributes

| Legacy timeItem itemType | First-class attribute |
|---|---|
| SCHEDULED_DATE | matchUp.schedule.scheduledDate |
| SCHEDULED_TIME | matchUp.schedule.scheduledTime |
| ASSIGN_COURT | matchUp.schedule.courtId |
| ASSIGN_VENUE | matchUp.schedule.venueId |
| COURT_ORDER | matchUp.schedule.courtOrder |
| COURT_ANNOTATION | matchUp.schedule.courtAnnotation |
| ALLOCATE_COURTS | matchUp.schedule.allocatedCourts |
| TIME_MODIFIERS | matchUp.schedule.timeModifiers |
| HOME_PARTICIPANT_ID | matchUp.schedule.homeParticipantId |
| ASSIGN_OFFICIAL (SCHEDULE.ASSIGNMENT.OFFICIAL) | matchUp.schedule.official |

**Explicitly NOT promoted:** START_TIME / STOP_TIME / RESUME_TIME / END_TIME — `matchUpDuration()` walks the ordered timeItem history (multiple intermediate STOP/RESUME pairs encode suspension durations). These keep writing through `addTimeItem` directly.

## New helpers (mirror the Phase 0 extension helpers)

- `setFirstClassOrTimeItem` (generic) — mode-aware writer
- `setMatchUpFirstClassOrTimeItem` (matchUp wrapper) — resolves matchUp via `findDrawMatchUp`, delegates, emits `modifyMatchUpNotice`
- `firstClassOrTimeItem` — read helper (first-class first, latest-timeItem fallback)

## Read shim

`buildFullSchedule` in `getMatchUpScheduleDetails` now prefers `matchUp.schedule.<attr>` before falling back to the legacy timeItem entry. Records written in any mode hydrate to an identical `matchUp.schedule` object.

## Clear path

`clearMatchUpSchedule` wipes both the timeItem entries AND the corresponding `matchUp.schedule.<attribute>` fields via a new itemType→attribute mapping.

## Pre-existing caller fixes

Typed `schedule?:` no longer matches the permissive index signature that lived on `HydratedMatchUp`. Targeted null-guards added in `proAutoSchedule`, `proConflicts`, `generateBookings`, `clearScheduledMatchUps`, `processAlreadyScheduledMatchUps`.

## Tests

- New `matchUpScheduleFirstClass.test.ts` — 20 tests covering NATIVE / DUAL / LEGACY end-to-end on 7 engine-exposed writers + hydration shim + `clearMatchUpSchedule` semantics
- Three additional writers (`courtAnnotation`, `timeModifiers`, `homeParticipantId`) are covered transitively by the existing test fleet (LEGACY-pinned setup)
- **Full factory suite: 917 files / 9514 pass / 7 skip / 0 fail** (vs Phase 1 baseline 911/9494: +6 files of tests, +20 new tests, zero regressions)
- Lint + type-check green

## Breaking changes (v5.0.0-alpha)

In NATIVE mode (default), consumers reading raw `matchUp.timeItems[]` for any of the 10 promoted itemTypes will find nothing. They must either:

- migrate to reading `matchUp.schedule.<attribute>` (this is also how hydrated matchUps already expose these values), or
- call `engine.schemaWriteMode('legacy')` / `'dual'` at startup

## Review focus

1. The `setFirstClassOrTimeItem` helper's LEGACY branch faithfully delegates to `addTimeItem` (including the historical undefined-value push behavior) — confirmed by the existing `scheduleMatchUps2` test which asserts exact timeItem ordering
2. The `itemDate` (courtDayDate) passthrough on ASSIGN_COURT / ALLOCATE_COURTS — preserved in LEGACY but dropped in NATIVE (no consumer reads it; confirmed by grep)
3. `itemSubTypes` passthrough on ASSIGN_OFFICIAL (carries officialType) — same: preserved in LEGACY, dropped in NATIVE
4. The narrowing of `schedule?:` typing surfaced 5 pre-existing callers that assumed schedule always existed — these fixes are intentional and small

## Test plan

- [ ] `pnpm check-types` green
- [ ] `pnpm lint` zero warnings
- [ ] `pnpm test --run` 917 files / 9514 pass / 7 skip
- [ ] Manual: NATIVE-mode `addMatchUpScheduledDate` → confirm `matchUp.schedule.scheduledDate` set, no `timeItems[{itemType:'SCHEDULED_DATE'}]`
- [ ] Manual: LEGACY-mode equivalent → confirm timeItem written, no first-class field
- [ ] Manual: DUAL-mode → confirm both surfaces match