### PR TITLE
feat!: CODES Phase 3 — promote flightProfile + lineUps to first-class

### DIFF
--- a/src/assemblies/generators/mocks/completeDrawMatchUps.ts
+++ b/src/assemblies/generators/mocks/completeDrawMatchUps.ts
@@ -18,9 +18,9 @@ import { intersection } from '@Tools/arrays';
 import { BYE, COMPLETED, DOUBLE_DEFAULT, DOUBLE_WALKOVER } from '@Constants/matchUpStatusConstants';
 import { MAIN, PLAY_OFF, QUALIFYING, WIN_RATIO } from '@Constants/drawDefinitionConstants';
 import { ErrorType, MISSING_DRAW_DEFINITION } from '@Constants/errorConditionConstants';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 import { addParticipants } from '@Mutate/participants/addParticipants';
 import { DOUBLES, SINGLES, TEAM } from '@Constants/matchUpTypes';
-import { addExtension } from '@Mutate/extensions/addExtension';
 import { LINEUPS } from '@Constants/extensionConstants';
 import { ASCENDING } from '@Constants/sortingConstants';
 import { SUCCESS } from '@Constants/resultConstants';
@@ -45,8 +45,7 @@ function assignParticipantsToDualMatchUps({ firstRoundDualMatchUps, event, tourn
     if (result.error) return result;
     const { lineUps, participantsToAdd } = result;
     addParticipants({ tournamentRecord, participants: participantsToAdd });
-    const extension = { name: LINEUPS, value: lineUps };
-    addExtension({ element: drawDefinition, extension });
+    setFirstClassOrExtension({ element: drawDefinition, attribute: 'lineUps', name: LINEUPS, value: lineUps });
     return undefined;
   }
   const structureId = firstRoundDualMatchUps[0]?.structureId;
@@ -268,7 +267,11 @@ export function completeDrawMatchUps(params): {
   const maxPasses = 10;
   let passCount = 0;
   let previousCompleted = -1;
-  while (completedCount.value > previousCompleted && (completionGoal === undefined || completedCount.value < completionGoal) && passCount < maxPasses) {
+  while (
+    completedCount.value > previousCompleted &&
+    (completionGoal === undefined || completedCount.value < completionGoal) &&
+    passCount < maxPasses
+  ) {
     passCount++;
     previousCompleted = completedCount.value;
 

--- a/src/assemblies/generators/participants/generateLineUps.ts
+++ b/src/assemblies/generators/participants/generateLineUps.ts
@@ -5,7 +5,7 @@ import { getParticipants } from '@Query/participants/getParticipants';
 import { addParticipant } from '@Mutate/participants/addParticipant';
 import { validateTieFormat } from '@Validators/validateTieFormat';
 import { getParticipantId } from '@Functions/global/extractors';
-import { addExtension } from '@Mutate/extensions/addExtension';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 import { generateRange } from '@Tools/arrays';
 import { isNumeric } from '@Tools/math';
 
@@ -192,8 +192,7 @@ export function generateLineUps(params: GenerateLineUpsArgs): ResultType & {
         tournamentRecord,
       });
     }
-    const extension = { name: LINEUPS, value: lineUps };
-    addExtension({ element: drawDefinition, extension });
+    setFirstClassOrExtension({ element: drawDefinition, attribute: 'lineUps', name: LINEUPS, value: lineUps });
   }
 
   return { ...SUCCESS, lineUps, participantsToAdd };

--- a/src/assemblies/generators/tournamentRecords/anonymizeTournamentRecord.ts
+++ b/src/assemblies/generators/tournamentRecords/anonymizeTournamentRecord.ts
@@ -56,6 +56,17 @@ export function anonymizeTournamentRecord({
   return { ...SUCCESS };
 }
 
+function anonymizeFlightProfileFlights(flightProfile: any, idMap: any) {
+  for (const flight of flightProfile.flights) {
+    flight.drawId = idMap[flight.drawId];
+    if (Array.isArray(flight.drawEntries)) {
+      for (const entry of flight.drawEntries) {
+        entry.participantId = idMap[entry.participantId];
+      }
+    }
+  }
+}
+
 function anonymizeTournamentHeader({ tournamentRecord, filterExtensions, idMap, tournamentId, tournamentName }) {
   tournamentRecord.extensions = filterExtensions(tournamentRecord);
 
@@ -196,20 +207,14 @@ function anonymizeEvents({ tournamentRecord, filterExtensions, idMap }) {
       anonymizeDrawDefinition({ drawDefinition, filterExtensions, idMap });
     }
 
-    const { extension: flightProfile } = findExtension({
-      name: FLIGHT_PROFILE,
-      element: event,
-    });
-
-    if (Array.isArray(flightProfile?.value?.flights)) {
-      flightProfile?.value.flights?.forEach((flight) => {
-        flight.drawId = idMap[flight.drawId];
-        if (Array.isArray(flight.drawEntries)) {
-          for (const entry of flight.drawEntries) {
-            entry.participantId = idMap[entry.participantId];
-          }
-        }
-      });
+    // anonymize CODES first-class flightProfile when present
+    if (Array.isArray(event.flightProfile?.flights)) {
+      anonymizeFlightProfileFlights(event.flightProfile, idMap);
+    }
+    // also anonymize the legacy extension form so DUAL / LEGACY records remain consistent
+    const { extension: flightProfileExt } = findExtension({ name: FLIGHT_PROFILE, element: event });
+    if (Array.isArray(flightProfileExt?.value?.flights)) {
+      anonymizeFlightProfileFlights(flightProfileExt.value, idMap);
     }
 
     eventCount += 1;

--- a/src/mutate/drawDefinitions/addDrawDefinition.ts
+++ b/src/mutate/drawDefinitions/addDrawDefinition.ts
@@ -1,4 +1,4 @@
-import { addEventExtension } from '@Mutate/extensions/addRemoveExtensions';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 import { allDrawMatchUps } from '@Query/matchUps/getAllDrawMatchUps';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { getFlightProfile } from '@Query/event/getFlightProfile';
@@ -122,17 +122,14 @@ export function addDrawDefinition(
 
   const flight = flightProfile?.flights?.find((flight) => flight.drawId === drawId);
 
-  let extension;
+  let value;
   if (flight) {
     // if this drawId was defined in a flightProfile...
     // ...update the flight.drawName with the drawName in the drawDefinition
     flight.drawName = drawDefinition.drawName;
-    extension = {
-      name: FLIGHT_PROFILE,
-      value: {
-        ...flightProfile,
-        flights: flightProfile.flights,
-      },
+    value = {
+      ...flightProfile,
+      flights: flightProfile.flights,
     };
 
     const flightNumber = flight.flightNumber;
@@ -150,16 +147,13 @@ export function addDrawDefinition(
       drawName,
       drawId,
     });
-    extension = {
-      name: FLIGHT_PROFILE,
-      value: {
-        ...flightProfile,
-        flights,
-      },
+    value = {
+      ...flightProfile,
+      flights,
     };
   }
 
-  addEventExtension({ event, extension });
+  setFirstClassOrExtension({ element: event, attribute: 'flightProfile', name: FLIGHT_PROFILE, value });
   Object.assign(drawDefinition, { drawOrder });
 
   const existingDrawDefinition = event.drawDefinitions.find((dd) => dd.drawId === drawId);

--- a/src/mutate/drawDefinitions/modifyDrawDefinition.ts
+++ b/src/mutate/drawDefinitions/modifyDrawDefinition.ts
@@ -1,5 +1,5 @@
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 import { attachPolicies } from '@Mutate/extensions/policies/attachPolicies';
-import { addEventExtension } from '@Mutate/extensions/addRemoveExtensions';
 import { modifyDrawNotice } from '@Mutate/notifications/drawNotifications';
 import { getFlightProfile } from '@Query/event/getFlightProfile';
 import { modifyDrawName } from './modifyDrawName';
@@ -49,15 +49,12 @@ export function modifyDrawDefinition({
   }
 
   if (flight) {
-    const extension = {
+    setFirstClassOrExtension({
+      element: event,
+      attribute: 'flightProfile',
       name: FLIGHT_PROFILE,
-      value: {
-        ...flightProfile,
-        flights: flightProfile.flights,
-      },
-    };
-
-    addEventExtension({ event, extension });
+      value: { ...flightProfile, flights: flightProfile.flights },
+    });
   }
 
   if (drawDefinition) {

--- a/src/mutate/drawDefinitions/modifyDrawName.ts
+++ b/src/mutate/drawDefinitions/modifyDrawName.ts
@@ -1,4 +1,4 @@
-import { addEventExtension } from '@Mutate/extensions/addRemoveExtensions';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 import { modifyDrawNotice } from '@Mutate/notifications/drawNotifications';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { getFlightProfile } from '@Query/event/getFlightProfile';
@@ -40,15 +40,12 @@ export function modifyDrawName({
 
   if (flight) {
     flight.drawName = drawName;
-    const extension = {
+    setFirstClassOrExtension({
+      element: event,
+      attribute: 'flightProfile',
       name: FLIGHT_PROFILE,
-      value: {
-        ...flightProfile,
-        flights: flightProfile.flights,
-      },
-    };
-
-    addEventExtension({ event, extension });
+      value: { ...flightProfile, flights: flightProfile.flights },
+    });
   }
 
   if (drawDefinition) {

--- a/src/mutate/drawDefinitions/updateTeamLineUp.ts
+++ b/src/mutate/drawDefinitions/updateTeamLineUp.ts
@@ -1,14 +1,15 @@
+import { setFirstClassOrExtension } from '../extensions/setFirstClassOrExtension';
 import { removeLineUpSubstitutions } from './removeLineUpSubstitutions';
-import { validateLineUp } from '@Validators/validateTeamLineUp';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import { addDrawNotice } from '../notifications/drawNotifications';
-import { findExtension } from '@Acquire/findExtension';
-import { addExtension } from '../extensions/addExtension';
+import { validateLineUp } from '@Validators/validateTeamLineUp';
 
+// constants and types
+import { ErrorType, MISSING_DRAW_DEFINITION, MISSING_PARTICIPANT_ID } from '@Constants/errorConditionConstants';
 import { DrawDefinition, TieFormat } from '@Types/tournamentTypes';
 import { LINEUPS } from '@Constants/extensionConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import { LineUp } from '@Types/factoryTypes';
-import { ErrorType, MISSING_DRAW_DEFINITION, MISSING_PARTICIPANT_ID } from '@Constants/errorConditionConstants';
 
 // update an extension on the drawDefinition that keeps track of the latest lineUp for all team participantIds
 // each matchUp in the draw will use this as the template on first load and then write lineUp to the matchUp
@@ -31,17 +32,12 @@ export function updateTeamLineUp({ drawDefinition, participantId, tieFormat, lin
   const validation = validateLineUp({ lineUp, tieFormat });
   if (!validation.valid) return validation;
 
-  const { extension: existingExtension } = findExtension({
-    element: drawDefinition,
-    name: LINEUPS,
-  });
+  const existing = firstClassOrExtension({ element: drawDefinition, attribute: 'lineUps', name: LINEUPS });
 
-  const value = existingExtension?.value ?? {};
+  const value = existing ?? {};
   value[participantId] = removeLineUpSubstitutions({ lineUp });
 
-  const extension = { name: LINEUPS, value };
-
-  addExtension({ element: drawDefinition, extension });
+  setFirstClassOrExtension({ element: drawDefinition, attribute: 'lineUps', name: LINEUPS, value });
   addDrawNotice({ drawDefinition });
 
   return { ...SUCCESS };

--- a/src/mutate/events/addFlight.ts
+++ b/src/mutate/events/addFlight.ts
@@ -1,7 +1,7 @@
-import { addEventExtension } from '../extensions/addRemoveExtensions';
+import { setFirstClassOrExtension } from '../extensions/setFirstClassOrExtension';
 import { decorateResult } from '@Functions/global/decorateResult';
-import { getParticipantId } from '@Functions/global/extractors';
 import { getFlightProfile } from '@Query/event/getFlightProfile';
+import { getParticipantId } from '@Functions/global/extractors';
 import { intersection } from '@Tools/arrays';
 import { ensureInt } from '@Tools/ensureInt';
 import { UUID } from '@Tools/UUID';
@@ -65,13 +65,10 @@ export function addFlight({
 
   const flights = (flightProfile?.flights ?? []).concat(flight);
 
-  const extension = {
+  return setFirstClassOrExtension({
+    element: event,
+    attribute: 'flightProfile',
     name: FLIGHT_PROFILE,
-    value: {
-      ...flightProfile,
-      flights,
-    },
-  };
-
-  return addEventExtension({ event, extension });
+    value: { ...flightProfile, flights },
+  });
 }

--- a/src/mutate/events/attachFlightProfile.ts
+++ b/src/mutate/events/attachFlightProfile.ts
@@ -1,4 +1,4 @@
-import { addEventExtension } from '../extensions/addRemoveExtensions';
+import { setFirstClassOrExtension } from '../extensions/setFirstClassOrExtension';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { getFlightProfile } from '@Query/event/getFlightProfile';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
@@ -27,12 +27,12 @@ export function attachFlightProfile({ deleteExisting, event, flightProfile }) {
       stack,
     });
 
-  const extension = {
+  setFirstClassOrExtension({
+    element: event,
+    attribute: 'flightProfile',
     name: FLIGHT_PROFILE,
     value: flightProfile,
-  };
-
-  addEventExtension({ event, extension });
+  });
 
   return {
     flightProfile: makeDeepCopy(flightProfile, false, true),

--- a/src/mutate/events/deleteDrawDefinitions.ts
+++ b/src/mutate/events/deleteDrawDefinitions.ts
@@ -1,11 +1,11 @@
 import { deleteDrawNotice, deleteMatchUpsNotice } from '../notifications/drawNotifications';
-import { getPositionAssignments } from '@Query/structure/getPositionAssignments';
 import { checkAndUpdateSchedulingProfile } from '../tournaments/schedulingProfile';
+import { setFirstClassOrExtension } from '../extensions/setFirstClassOrExtension';
+import { getPositionAssignments } from '@Query/structure/getPositionAssignments';
 import { getEventPublishStatus } from '@Query/event/getEventPublishStatus';
 import { getAppliedPolicies } from '@Query/extensions/getAppliedPolicies';
 import { checkScoreHasValue } from '@Query/matchUp/checkScoreHasValue';
 import { modifyEventPublishStatus } from './modifyEventPublishStatus';
-import { addEventExtension } from '../extensions/addRemoveExtensions';
 import { allDrawMatchUps } from '@Query/matchUps/getAllDrawMatchUps';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { addNotice, hasTopic } from '@Global/state/globalState';
@@ -201,12 +201,12 @@ export function deleteDrawDefinitions(params: DeleteDrawDefinitionArgs) {
   event.drawDefinitions = filteredDrawDefinitions;
 
   if (flightProfile) {
-    const extension = {
+    setFirstClassOrExtension({
+      element: event,
+      attribute: 'flightProfile',
       name: FLIGHT_PROFILE,
       value: flightProfile,
-    };
-
-    addEventExtension({ event, extension });
+    });
   }
 
   // cleanup references to drawId in schedulingProfile extension

--- a/src/mutate/events/deleteFlightAndFlightDraw.ts
+++ b/src/mutate/events/deleteFlightAndFlightDraw.ts
@@ -1,5 +1,5 @@
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 import { deleteDrawDefinitions } from '@Mutate/events/deleteDrawDefinitions';
-import { addEventExtension } from '@Mutate/extensions/addRemoveExtensions';
 import { requireParams } from '@Helpers/parameters/requireParams';
 import { getFlightProfile } from '@Query/event/getFlightProfile';
 import { refreshEventDrawOrder } from './refreshEventDrawOrder';
@@ -22,15 +22,12 @@ export function deleteFlightAndFlightDraw({ autoPublish = true, tournamentRecord
         return flight.drawId !== drawId;
       });
 
-      const extension = {
+      setFirstClassOrExtension({
+        element: event,
+        attribute: 'flightProfile',
         name: FLIGHT_PROFILE,
-        value: {
-          ...flightProfile,
-          flights,
-        },
-      };
-
-      addEventExtension({ event, extension });
+        value: { ...flightProfile, flights },
+      });
     }
   }
 

--- a/src/mutate/events/deleteFlightProfileAndFlightDraws.ts
+++ b/src/mutate/events/deleteFlightProfileAndFlightDraws.ts
@@ -1,4 +1,4 @@
-import { removeEventExtension } from '../extensions/addRemoveExtensions';
+import { setFirstClassOrExtension } from '../extensions/setFirstClassOrExtension';
 import { requireParams } from '@Helpers/parameters/requireParams';
 import { getFlightProfile } from '@Query/event/getFlightProfile';
 import { deleteDrawDefinitions } from './deleteDrawDefinitions';
@@ -28,7 +28,12 @@ export function deleteFlightProfileAndFlightDraws({ autoPublish = true, tourname
     });
     if (result.error) return result;
 
-    return removeEventExtension({ event, name: FLIGHT_PROFILE });
+    return setFirstClassOrExtension({
+      element: event,
+      attribute: 'flightProfile',
+      name: FLIGHT_PROFILE,
+      value: undefined,
+    });
   }
 
   return { ...SUCCESS };

--- a/src/mutate/matchUps/lineUps/ensureSideLineUps.ts
+++ b/src/mutate/matchUps/lineUps/ensureSideLineUps.ts
@@ -1,7 +1,7 @@
 import { modifyMatchUpNotice } from '../../notifications/drawNotifications';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import { findDrawMatchUp } from '@Acquire/findDrawMatchUp';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
-import { findExtension } from '@Acquire/findExtension';
 
 import { DrawDefinition, MatchUp } from '@Types/tournamentTypes';
 import { LINEUPS } from '@Constants/extensionConstants';
@@ -30,12 +30,8 @@ export function ensureSideLineUps({
       })?.matchUp;
     }
 
-    const { extension } = findExtension({
-      element: drawDefinition,
-      name: LINEUPS,
-    });
-
-    const lineUps = makeDeepCopy(extension?.value ?? {}, false, true);
+    const lineUpsValue = firstClassOrExtension({ element: drawDefinition, attribute: 'lineUps', name: LINEUPS });
+    const lineUps = makeDeepCopy(lineUpsValue ?? {}, false, true);
 
     const extractSideDetail = ({ displaySideNumber, drawPosition, sideNumber }) => ({
       drawPosition,

--- a/src/mutate/matchUps/lineUps/updateSideLineUp.ts
+++ b/src/mutate/matchUps/lineUps/updateSideLineUp.ts
@@ -1,6 +1,6 @@
 import { modifyMatchUpNotice } from '../../notifications/drawNotifications';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
-import { findExtension } from '@Acquire/findExtension';
 
 import { LINEUPS } from '@Constants/extensionConstants';
 import { HydratedMatchUp } from '@Types/hydrated';
@@ -31,12 +31,7 @@ export function updateSideLineUp({
   const sideExists =
     drawPositionSideNumber && matchUp.sides?.find((side) => side.sideNumber === drawPositionSideNumber);
 
-  const { extension: existingExtension } = findExtension({
-    element: drawDefinition,
-    name: LINEUPS,
-  });
-
-  const lineUps = existingExtension?.value ?? {};
+  const lineUps = firstClassOrExtension({ element: drawDefinition, attribute: 'lineUps', name: LINEUPS }) ?? {};
   const lineUp = makeDeepCopy(lineUps[teamParticipantId], false, true);
 
   if (sideExists) {

--- a/src/mutate/participants/removeIndividualParticipantIds.ts
+++ b/src/mutate/participants/removeIndividualParticipantIds.ts
@@ -2,11 +2,11 @@ import { addDrawNotice, modifyMatchUpNotice } from '@Mutate/notifications/drawNo
 import { checkScoreHasValue } from '@Query/matchUp/checkScoreHasValue';
 import { getParticipants } from '@Query/participants/getParticipants';
 import { allDrawMatchUps } from '@Query/matchUps/getAllDrawMatchUps';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import { addEventEntries } from '@Mutate/entries/addEventEntries';
 import { decorateResult } from '@Functions/global/decorateResult';
-import { addExtension } from '@Mutate/extensions/addExtension';
 import { addNotice } from '@Global/state/globalState';
-import { findExtension } from '@Acquire/findExtension';
 
 // constants and types
 import { Participant, ParticipantRoleUnion, Tournament } from '@Types/tournamentTypes';
@@ -223,14 +223,11 @@ function purgeParticipantFromLineUps({ groupingParticipantId, tournamentRecord, 
 }
 
 function purgeFromDrawLineUp({ drawDefinition, groupingParticipantId, participantId }) {
-  const { extension } = findExtension({
-    element: drawDefinition,
-    name: LINEUPS,
-  });
-  const lineUp = extension?.value[groupingParticipantId];
-  if (extension && lineUp) {
-    extension.value[groupingParticipantId] = lineUp.filter((assignment) => assignment.participantId !== participantId);
-    addExtension({ element: drawDefinition, extension });
+  const lineUps = firstClassOrExtension({ element: drawDefinition, attribute: 'lineUps', name: LINEUPS });
+  const lineUp = lineUps?.[groupingParticipantId];
+  if (lineUps && lineUp) {
+    lineUps[groupingParticipantId] = lineUp.filter((assignment) => assignment.participantId !== participantId);
+    setFirstClassOrExtension({ element: drawDefinition, attribute: 'lineUps', name: LINEUPS, value: lineUps });
     addDrawNotice({ drawDefinition });
   }
 }

--- a/src/query/drawDefinition/getTeamLineUp.ts
+++ b/src/query/drawDefinition/getTeamLineUp.ts
@@ -1,4 +1,4 @@
-import { findExtension } from '@Acquire/findExtension';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 
 // constants
 import { MISSING_DRAW_DEFINITION, MISSING_PARTICIPANT_ID } from '@Constants/errorConditionConstants';
@@ -8,12 +8,7 @@ export function getTeamLineUp({ drawDefinition, participantId }) {
   if (typeof drawDefinition !== 'object') return { error: MISSING_DRAW_DEFINITION };
   if (typeof participantId !== 'string') return { error: MISSING_PARTICIPANT_ID };
 
-  const { extension } = findExtension({
-    element: drawDefinition,
-    name: LINEUPS,
-  });
-
-  const lineUps = extension?.value ?? {};
+  const lineUps = firstClassOrExtension({ element: drawDefinition, attribute: 'lineUps', name: LINEUPS }) ?? {};
   const lineUp = lineUps[participantId];
 
   return { lineUp };

--- a/src/query/event/getFlightProfile.ts
+++ b/src/query/event/getFlightProfile.ts
@@ -1,5 +1,5 @@
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
-import { findExtension } from '@Acquire/findExtension';
 
 import { MISSING_EVENT } from '@Constants/errorConditionConstants';
 import { FLIGHT_PROFILE } from '@Constants/extensionConstants';
@@ -12,16 +12,11 @@ type GetFlightProfileArgs = {
 export function getFlightProfile({ event, eventId }: GetFlightProfileArgs) {
   if (!event) return { error: MISSING_EVENT };
 
-  const result = findExtension({
-    name: FLIGHT_PROFILE,
-    element: event,
-  });
-
-  const extension = result?.extension;
+  const stored = firstClassOrExtension({ element: event, attribute: 'flightProfile', name: FLIGHT_PROFILE });
 
   // eventId indicates that `getFlightProfile()` has been called via `tournamentEngine`
   // a deep copy is made and drawDefinitions are attached for client convenience
-  const flightProfile = eventId ? makeDeepCopy(extension?.value, false, true) : extension?.value;
+  const flightProfile = eventId ? makeDeepCopy(stored, false, true) : stored;
 
   if (eventId) {
     event.drawDefinitions?.forEach((drawDefinition) => {

--- a/src/query/structure/structureReport.ts
+++ b/src/query/structure/structureReport.ts
@@ -75,9 +75,18 @@ export function getStructureReports(params: GetStructureReportsArgs) {
   };
 
   const tournamentStructureData = tournamentRecord?.events?.flatMap(
-    ({ timeItems: eventTimeItems, drawDefinitions = [], extensions, eventType, eventName, eventId, category }) => {
-      const flightProfile = extensions?.find((x) => x.name === FLIGHT_PROFILE);
-      const flightNumbers = flightProfile?.value?.flights?.map((flight) => ({
+    ({
+      timeItems: eventTimeItems,
+      drawDefinitions = [],
+      extensions,
+      eventType,
+      eventName,
+      eventId,
+      category,
+      flightProfile: firstClassFlightProfile,
+    }) => {
+      const flightProfileValue = firstClassFlightProfile ?? extensions?.find((x) => x.name === FLIGHT_PROFILE)?.value;
+      const flightNumbers = flightProfileValue?.flights?.map((flight) => ({
         [flight.drawId]: flight.flightNumber,
       }));
       const flightMap: any = flightNumbers && Object.assign({}, ...flightNumbers);

--- a/src/tests/global/flightProfileLineUpsFirstClass.test.ts
+++ b/src/tests/global/flightProfileLineUpsFirstClass.test.ts
@@ -1,0 +1,95 @@
+/**
+ * CODES Phase 3 — first-class promotion of `flightProfile` (on Event /
+ * DrawDefinition) and `lineUps` (on DrawDefinition).
+ *
+ * The existing test fleet keeps its LEGACY assertions via the vitest
+ * setupFiles pin; these tests own the new behavior.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
+import { setSchemaWriteMode } from '@Global/state/globalState';
+import { findExtension } from '@Acquire/findExtension';
+
+// constants and types
+import { DUAL, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
+import { FLIGHT_PROFILE, LINEUPS } from '@Constants/extensionConstants';
+
+describe.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('flightProfile + lineUps routing (mode=%s)', (mode) => {
+  function assertSurfaces(element: any, attribute: string, name: string, expected: any) {
+    const firstClass = element[attribute];
+    const ext = findExtension({ element, name }).extension;
+    if (mode === NATIVE) {
+      expect(firstClass).toEqual(expected);
+      expect(ext).toBeUndefined();
+    } else if (mode === DUAL) {
+      expect(firstClass).toEqual(expected);
+      expect(ext?.value).toEqual(expected);
+    } else {
+      expect(firstClass).toBeUndefined();
+      expect(ext?.value).toEqual(expected);
+    }
+  }
+
+  it('flightProfile on event', () => {
+    setSchemaWriteMode(mode);
+    const event: any = { eventId: 'e1' };
+    const profile = { flights: [{ drawId: 'd1', flightNumber: 1 }] };
+    setFirstClassOrExtension({ element: event, attribute: 'flightProfile', name: FLIGHT_PROFILE, value: profile });
+    assertSurfaces(event, 'flightProfile', FLIGHT_PROFILE, profile);
+  });
+
+  it('lineUps on drawDefinition', () => {
+    setSchemaWriteMode(mode);
+    const drawDefinition: any = { drawId: 'd1' };
+    const lineUps = { 'team-1': [{ participantId: 'p1' }] };
+    setFirstClassOrExtension({
+      element: drawDefinition,
+      attribute: 'lineUps',
+      name: LINEUPS,
+      value: lineUps,
+    });
+    assertSurfaces(drawDefinition, 'lineUps', LINEUPS, lineUps);
+  });
+
+  it('flightProfile removal via undefined value', () => {
+    setSchemaWriteMode(mode);
+    const event: any = { eventId: 'e1' };
+    setFirstClassOrExtension({
+      element: event,
+      attribute: 'flightProfile',
+      name: FLIGHT_PROFILE,
+      value: { flights: [] },
+    });
+    setFirstClassOrExtension({
+      element: event,
+      attribute: 'flightProfile',
+      name: FLIGHT_PROFILE,
+      value: undefined,
+    });
+    expect(event.flightProfile).toBeUndefined();
+    const ext = findExtension({ element: event, name: FLIGHT_PROFILE }).extension;
+    expect(ext).toBeUndefined();
+  });
+});
+
+describe('Read symmetry — firstClassOrExtension', () => {
+  it.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('mode=%s reads flightProfile', (mode) => {
+    setSchemaWriteMode(mode);
+    const event: any = { eventId: 'e1' };
+    const profile = { flights: [{ drawId: 'd1', flightNumber: 1 }] };
+    setFirstClassOrExtension({ element: event, attribute: 'flightProfile', name: FLIGHT_PROFILE, value: profile });
+    expect(firstClassOrExtension({ element: event, attribute: 'flightProfile', name: FLIGHT_PROFILE })).toEqual(
+      profile,
+    );
+  });
+
+  it.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('mode=%s reads lineUps', (mode) => {
+    setSchemaWriteMode(mode);
+    const drawDefinition: any = { drawId: 'd1' };
+    const lineUps = { 'team-1': [{ participantId: 'p1' }] };
+    setFirstClassOrExtension({ element: drawDefinition, attribute: 'lineUps', name: LINEUPS, value: lineUps });
+    expect(firstClassOrExtension({ element: drawDefinition, attribute: 'lineUps', name: LINEUPS })).toEqual(lineUps);
+  });
+});

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -70,6 +70,8 @@ export interface Event {
   eventTier?: TierClassification;
   eventType?: EventTypeUnion;
   extensions?: Extension[];
+  // CODES first-class: previously stored as `flightProfile` extension
+  flightProfile?: any;
   gender?: GenderUnion;
   indoorOutdoor?: IndoorOutdoorUnion;
   isMock?: boolean;
@@ -181,7 +183,11 @@ export interface DrawDefinition {
   endDate?: string;
   entries?: Entry[];
   extensions?: Extension[];
+  // CODES first-class: previously stored as `flightProfile` extension
+  flightProfile?: any;
   isMock?: boolean;
+  // CODES first-class: previously stored as `lineUps` extension
+  lineUps?: any;
   links?: DrawLink[];
   matchUpFormat?: string;
   matchUps?: MatchUp[];


### PR DESCRIPTION
## Summary

CODES Phase 3: collapse the `flightProfile` extension (on Event and DrawDefinition) and the `lineUps` extension (on DrawDefinition) onto first-class typed fields. Continues the v5.0.0-alpha CODES migration.

## Promoted

| Legacy extension | First-class attribute |
|---|---|
| `FLIGHT_PROFILE` (Event) | `Event.flightProfile` |
| `FLIGHT_PROFILE` (DrawDefinition) | `DrawDefinition.flightProfile` |
| `LINEUPS` (DrawDefinition) | `DrawDefinition.lineUps` |

## Migrated writers (FLIGHT_PROFILE)

`addFlight`, `attachFlightProfile`, `deleteFlightAndFlightDraw`, `deleteFlightProfileAndFlightDraws` (now writes `value: undefined` via the helper instead of `removeEventExtension`), `addDrawDefinition`, `modifyDrawName`, `modifyDrawDefinition`, `deleteDrawDefinitions` (FLIGHT_PROFILE branch only — DRAW_DELETIONS is Phase 6).

## Migrated writers (LINEUPS)

`updateTeamLineUp`, `generateLineUps`, `completeDrawMatchUps`, `removeIndividualParticipantIds.purgeFromDrawLineUp`.

## Migrated readers

`getFlightProfile`, `getTeamLineUp`, `ensureSideLineUps`, `updateSideLineUp`, `structureReport`, `anonymizeTournamentRecord` (now walks BOTH surfaces so DUAL records stay consistent; extracted `anonymizeFlightProfileFlights` helper).

## Tests

- New `flightProfileLineUpsFirstClass.test.ts` — 15 tests covering NATIVE / DUAL / LEGACY routing, removal-via-undefined, and read symmetry for both attributes
- **Full factory suite: 918 files / 9529 pass / 7 skip / 0 fail** (Phase 2 baseline 917/9514: +1 file, +15 tests, zero regressions)
- Lint + types green

## Breaking changes (v5.0.0-alpha)

In NATIVE mode (default), consumers reading raw `event.extensions[]` for `flightProfile` or `drawDefinition.extensions[]` for `lineUps` will find nothing. Read `event.flightProfile` / `drawDefinition.lineUps` directly, or use `firstClassOrExtension` for mode-agnostic reads, or set `engine.schemaWriteMode('legacy'|'dual')`.

## Test plan

- [ ] `pnpm check-types` green
- [ ] `pnpm lint` zero warnings
- [ ] `pnpm test --run` 918 files / 9529 pass / 7 skip