### PR TITLE
feat!: CODES Phase 4 — promote flat scalar / object extensions

### DIFF
--- a/src/acquire/findStructure.ts
+++ b/src/acquire/findStructure.ts
@@ -1,6 +1,6 @@
 import { checkRequiredParameters } from '@Helpers/parameters/checkRequiredParameters';
 import { structureSort } from '@Functions/sorters/structureSort';
-import { findExtension } from '@Acquire/findExtension';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 
 // constants and types
 import { MISSING_STRUCTURES, STRUCTURE_NOT_FOUND, MISSING_DRAW_DEFINITION } from '@Constants/errorConditionConstants';
@@ -75,10 +75,7 @@ export function getDrawStructures({
   if (error) return { error, structures: [], stageStructures: {} };
 
   const isRoundTarget = (structure) => {
-    const value = findExtension({
-      element: structure,
-      name: ROUND_TARGET,
-    })?.extension?.value;
+    const value = firstClassOrExtension({ element: structure, attribute: 'roundTarget', name: ROUND_TARGET });
     return !roundTarget || roundTarget === value;
   };
 

--- a/src/assemblies/generators/drawDefinitions/drawTypes/generateQualifyingStructure.ts
+++ b/src/assemblies/generators/drawDefinitions/drawTypes/generateQualifyingStructure.ts
@@ -4,7 +4,7 @@ import { getAllStructureMatchUps } from '@Query/matchUps/getAllStructureMatchUps
 import { getStructureGroups } from '@Query/structure/getStructureGroups';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { coerceEven, isConvertableInteger } from '@Tools/math';
-import { addExtension } from '@Mutate/extensions/addExtension';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 import { generateRoundRobin } from './roundRobin/roundRobin';
 import { generateTieMatchUps } from '../tieMatchUps';
 import { constantToString } from '@Tools/strings';
@@ -127,9 +127,11 @@ function generateEliminationStructure(args: any) {
   });
 
   if (args.roundTarget) {
-    addExtension({
-      extension: { name: ROUND_TARGET, value: args.roundTarget },
+    setFirstClassOrExtension({
       element: structure,
+      attribute: 'roundTarget',
+      name: ROUND_TARGET,
+      value: args.roundTarget,
     });
   }
 

--- a/src/assemblies/generators/drawDefinitions/drawTypes/generateQualifyingStructures.ts
+++ b/src/assemblies/generators/drawDefinitions/drawTypes/generateQualifyingStructures.ts
@@ -3,7 +3,7 @@ import { getAllStructureMatchUps } from '@Query/matchUps/getAllStructureMatchUps
 import structureTemplate from '@Generators/templates/structureTemplate';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { coerceEven, isConvertableInteger } from '@Tools/math';
-import { addExtension } from '@Mutate/extensions/addExtension';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 import { generateRoundRobin } from './roundRobin/roundRobin';
 import { constantToString } from '@Tools/strings';
 import { treeMatchUps } from './eliminationTree';
@@ -224,9 +224,11 @@ function processStructureProfile({
     });
 
     if (roundTarget) {
-      addExtension({
-        extension: { name: ROUND_TARGET, value: roundTarget },
+      setFirstClassOrExtension({
         element: structure,
+        attribute: 'roundTarget',
+        name: ROUND_TARGET,
+        value: roundTarget,
       });
     }
 

--- a/src/assemblies/generators/drawDefinitions/drawTypes/roundRobin/roundRobin.ts
+++ b/src/assemblies/generators/drawDefinitions/drawTypes/roundRobin/roundRobin.ts
@@ -1,6 +1,6 @@
 import { getRoundRobinGroupMatchUps, drawPositionsHash, groupRounds } from './roundRobinGroups';
 import { structureTemplate } from '@Generators/templates/structureTemplate';
-import { addExtension } from '@Mutate/extensions/addExtension';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 import { constantToString } from '@Tools/strings';
 import { generateRange } from '@Tools/arrays';
 import { UUID } from '@Tools/UUID';
@@ -111,9 +111,11 @@ export function generateRoundRobin(params: GenerateRoundRobinArgs) {
   });
 
   if (roundTarget)
-    addExtension({
-      extension: { name: ROUND_TARGET, value: roundTarget },
+    setFirstClassOrExtension({
       element: structure,
+      attribute: 'roundTarget',
+      name: ROUND_TARGET,
+      value: roundTarget,
     });
 
   return {

--- a/src/functions/sorters/structureSort.ts
+++ b/src/functions/sorters/structureSort.ts
@@ -1,4 +1,4 @@
-import { findExtension } from '@Acquire/findExtension';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 
 // constants and types
 import { completedMatchUpStatuses } from '@Constants/matchUpStatusConstants';
@@ -14,7 +14,7 @@ import {
 } from '@Constants/drawDefinitionConstants';
 
 export function structureSort(a: Structure | undefined, b: Structure | undefined, config?): number {
-  const getRoundTarget = (element) => findExtension({ element, name: ROUND_TARGET })?.extension?.value;
+  const getRoundTarget = (element) => firstClassOrExtension({ element, attribute: 'roundTarget', name: ROUND_TARGET });
 
   const completed = config?.deprioritizeCompleted;
   const aggregate = config?.mode === AGGREGATE_EVENT_STRUCTURES && aggregateOrder;

--- a/src/mutate/drawDefinitions/competition/initializeCompetitionState.ts
+++ b/src/mutate/drawDefinitions/competition/initializeCompetitionState.ts
@@ -5,7 +5,7 @@ import { getCompetitionPolicy } from '@Query/drawDefinition/competition/getCompe
 import { getAdHocRatings } from '@Generators/drawDefinitions/drawTypes/adHoc/drawMatic/getAdHocRatings';
 
 // Mutate
-import { addExtension } from '@Mutate/extensions/addExtension';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 
 // Constants
 import { MISSING_DRAW_DEFINITION, MISSING_VALUE } from '@Constants/errorConditionConstants';
@@ -29,9 +29,7 @@ type InitializeCompetitionStateResult = ResultType & {
   competitionState?: CompetitionState;
 };
 
-export function initializeCompetitionState(
-  params: InitializeCompetitionStateArgs,
-): InitializeCompetitionStateResult {
+export function initializeCompetitionState(params: InitializeCompetitionStateArgs): InitializeCompetitionStateResult {
   const { tournamentRecord, drawDefinition, participantIds, event } = params;
   if (!drawDefinition) return { error: MISSING_DRAW_DEFINITION };
   if (!participantIds?.length) return { error: MISSING_VALUE };
@@ -45,9 +43,7 @@ export function initializeCompetitionState(
   const eventType = event?.eventType;
 
   // Resolve baseline ratings using the same infrastructure as DrawMatic
-  const adHocRatings = scaleName
-    ? getAdHocRatings({ tournamentRecord, participantIds, scaleName, eventType })
-    : {};
+  const adHocRatings = scaleName ? getAdHocRatings({ tournamentRecord, participantIds, scaleName, eventType }) : {};
 
   const participantStates: Record<string, CompetitionParticipantState> = {};
 
@@ -80,9 +76,11 @@ export function initializeCompetitionState(
     roundStates: {},
   };
 
-  addExtension({
+  setFirstClassOrExtension({
     element: drawDefinition,
-    extension: { name: COMPETITION_STATE, value: competitionState },
+    attribute: 'competitionState',
+    name: COMPETITION_STATE,
+    value: competitionState,
   });
 
   return { competitionState, ...SUCCESS };

--- a/src/mutate/drawDefinitions/competition/processCompetitionMatchUp.ts
+++ b/src/mutate/drawDefinitions/competition/processCompetitionMatchUp.ts
@@ -8,7 +8,7 @@ import { computeActualOutput } from '@Generators/scales/competition/actualOutput
 import { expectedScore } from '@Generators/scales/competition/expectedScore';
 
 // Mutate
-import { addExtension } from '@Mutate/extensions/addExtension';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 
 // Constants
 import { MISSING_DRAW_DEFINITION, MISSING_MATCHUP } from '@Constants/errorConditionConstants';
@@ -128,9 +128,11 @@ export function processCompetitionMatchUp(params: ProcessCompetitionMatchUpArgs)
   });
 
   // Persist updated state
-  addExtension({
+  setFirstClassOrExtension({
     element: drawDefinition,
-    extension: { name: COMPETITION_STATE, value: competitionState },
+    attribute: 'competitionState',
+    name: COMPETITION_STATE,
+    value: competitionState,
   });
 
   return { ...SUCCESS };

--- a/src/mutate/drawDefinitions/competition/processCompetitionRound.ts
+++ b/src/mutate/drawDefinitions/competition/processCompetitionRound.ts
@@ -4,7 +4,7 @@ import { getCompetitionState } from '@Query/drawDefinition/competition/getCompet
 
 // Mutate
 import { processCompetitionMatchUp } from './processCompetitionMatchUp';
-import { addExtension } from '@Mutate/extensions/addExtension';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 
 // Constants
 import { completedMatchUpStatuses } from '@Constants/matchUpStatusConstants';
@@ -55,9 +55,11 @@ export function processCompetitionRound(params: ProcessCompetitionRoundArgs): Re
       processed: true,
     };
 
-    addExtension({
+    setFirstClassOrExtension({
       element: drawDefinition,
-      extension: { name: COMPETITION_STATE, value: updatedState },
+      attribute: 'competitionState',
+      name: COMPETITION_STATE,
+      value: updatedState,
     });
   }
 

--- a/src/mutate/drawDefinitions/competition/resetCompetitionState.ts
+++ b/src/mutate/drawDefinitions/competition/resetCompetitionState.ts
@@ -1,5 +1,5 @@
 // Mutate
-import { addExtension } from '@Mutate/extensions/addExtension';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 
 // Constants
 import { MISSING_DRAW_DEFINITION } from '@Constants/errorConditionConstants';
@@ -17,9 +17,11 @@ type ResetCompetitionStateArgs = {
 export function resetCompetitionState({ drawDefinition }: ResetCompetitionStateArgs): ResultType {
   if (!drawDefinition) return { error: MISSING_DRAW_DEFINITION };
 
-  addExtension({
+  setFirstClassOrExtension({
     element: drawDefinition,
-    extension: { name: COMPETITION_STATE, value: undefined },
+    attribute: 'competitionState',
+    name: COMPETITION_STATE,
+    value: undefined,
   });
 
   return { ...SUCCESS };

--- a/src/mutate/drawDefinitions/draft/initializeDraft.ts
+++ b/src/mutate/drawDefinitions/draft/initializeDraft.ts
@@ -1,7 +1,7 @@
 import { getParticipantScaleItem } from '@Query/participant/getParticipantScaleItem';
 import { getPositionAssignments } from '@Query/drawDefinition/positionsGetter';
-import { addExtension } from '@Mutate/extensions/addExtension';
-import { findExtension } from '@Acquire/findExtension';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import { findStructure } from '@Acquire/findStructure';
 
 // constants and types
@@ -63,8 +63,8 @@ export function initializeDraft({
   if (!structure) return { error: MISSING_STRUCTURE_ID };
 
   // check for existing draft
-  const { extension: existing } = findExtension({ element: drawDefinition, name: DRAFT_STATE });
-  if (existing?.value?.status && existing.value.status !== 'COMPLETE' && !force) {
+  const existing = firstClassOrExtension({ element: drawDefinition, attribute: 'draftState', name: DRAFT_STATE });
+  if (existing?.status && existing.status !== 'COMPLETE' && !force) {
     return { error: EXISTING_DRAFT };
   }
 
@@ -125,9 +125,11 @@ export function initializeDraft({
     unassignedDrawPositions: unassignedPositions,
   };
 
-  addExtension({
+  setFirstClassOrExtension({
     element: drawDefinition,
-    extension: { name: DRAFT_STATE, value: draftState },
+    attribute: 'draftState',
+    name: DRAFT_STATE,
+    value: draftState,
   });
 
   return {

--- a/src/mutate/drawDefinitions/draft/resolveDraftPositions.ts
+++ b/src/mutate/drawDefinitions/draft/resolveDraftPositions.ts
@@ -1,8 +1,8 @@
 import { assignDrawPosition as assignPosition } from '@Mutate/matchUps/drawPositions/positionAssignment';
 import { resolveDrawPositions } from '@Assemblies/generators/drawDefinitions/drawPositionsResolver';
 import { getPositionAssignments } from '@Query/drawDefinition/positionsGetter';
-import { addExtension } from '@Mutate/extensions/addExtension';
-import { findExtension } from '@Acquire/findExtension';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import { findStructure } from '@Acquire/findStructure';
 
 // constants and types
@@ -30,10 +30,8 @@ export function resolveDraftPositions({
 }: ResolveDraftPositionsArgs) {
   if (!drawDefinition) return { error: MISSING_DRAW_DEFINITION };
 
-  const { extension } = findExtension({ element: drawDefinition, name: DRAFT_STATE });
-  if (!extension?.value) return { error: NOT_FOUND, info: 'No active draft found' };
-
-  const draftState = extension.value;
+  const draftState = firstClassOrExtension({ element: drawDefinition, attribute: 'draftState', name: DRAFT_STATE });
+  if (!draftState) return { error: NOT_FOUND, info: 'No active draft found' };
   if (draftState.status === 'COMPLETE') return { error: INVALID_VALUES, info: 'Draft is already complete' };
 
   const structureId = draftState.structureId;
@@ -202,9 +200,11 @@ function applyResolutions({
     draftState.transparencyReport = transparencyReport;
   }
 
-  addExtension({
+  setFirstClassOrExtension({
     element: drawDefinition,
-    extension: { name: DRAFT_STATE, value: draftState },
+    attribute: 'draftState',
+    name: DRAFT_STATE,
+    value: draftState,
   });
 
   if (errors.length) {

--- a/src/mutate/drawDefinitions/draft/setDrawPositionPreferences.ts
+++ b/src/mutate/drawDefinitions/draft/setDrawPositionPreferences.ts
@@ -1,5 +1,5 @@
-import { addExtension } from '@Mutate/extensions/addExtension';
-import { findExtension } from '@Acquire/findExtension';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 
 // constants and types
 import { DrawDefinition, Tournament } from '@Types/tournamentTypes';
@@ -28,10 +28,8 @@ export function setDrawPositionPreferences({
   if (!participantId) return { error: INVALID_PARTICIPANT_ID };
   if (!Array.isArray(preferences)) return { error: INVALID_VALUES };
 
-  const { extension } = findExtension({ element: drawDefinition, name: DRAFT_STATE });
-  if (!extension?.value) return { error: NOT_FOUND, info: 'No active draft found' };
-
-  const draftState = extension.value;
+  const draftState = firstClassOrExtension({ element: drawDefinition, attribute: 'draftState', name: DRAFT_STATE });
+  if (!draftState) return { error: NOT_FOUND, info: 'No active draft found' };
 
   // verify draft is in a state that accepts preferences
   if (draftState.status === 'COMPLETE') return { error: INVALID_VALUES, info: 'Draft is already complete' };
@@ -60,9 +58,11 @@ export function setDrawPositionPreferences({
     draftState.status = 'COLLECTING_PREFERENCES';
   }
 
-  addExtension({
+  setFirstClassOrExtension({
     element: drawDefinition,
-    extension: { name: DRAFT_STATE, value: draftState },
+    attribute: 'draftState',
+    name: DRAFT_STATE,
+    value: draftState,
   });
 
   return { ...SUCCESS };

--- a/src/mutate/drawDefinitions/entryGovernor/addDrawEntries.ts
+++ b/src/mutate/drawDefinitions/entryGovernor/addDrawEntries.ts
@@ -6,6 +6,7 @@ import { getValidStage } from '@Query/drawDefinition/getValidStage';
 import { getStageSpace } from '@Query/drawDefinition/getStageSpace';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { isValidExtension } from '@Validators/isValidExtension';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 import { addExtension } from '@Mutate/extensions/addExtension';
 import { isAdHocType } from '@Query/drawDefinition/isAdHocType';
 import { definedAttributes } from '@Tools/definedAttributes';
@@ -153,9 +154,11 @@ export function addDrawEntry(params: AddDrawEntryArgs) {
   }
 
   if (roundTarget) {
-    addExtension({
-      extension: { name: ROUND_TARGET, value: roundTarget },
+    setFirstClassOrExtension({
       element: entry,
+      attribute: 'roundTarget',
+      name: ROUND_TARGET,
+      value: roundTarget,
     });
   }
 
@@ -292,9 +295,11 @@ export function addDrawEntries(params: AddDrawEntriesArgs) {
         addExtension({ element: entry, extension });
       }
       if (roundTarget) {
-        addExtension({
-          extension: { name: ROUND_TARGET, value: roundTarget },
+        setFirstClassOrExtension({
           element: entry,
+          attribute: 'roundTarget',
+          name: ROUND_TARGET,
+          value: roundTarget,
         });
       }
       drawDefinition.entries ??= [];

--- a/src/mutate/drawDefinitions/matchUpGovernor/setDelegatedOutcome.ts
+++ b/src/mutate/drawDefinitions/matchUpGovernor/setDelegatedOutcome.ts
@@ -1,4 +1,4 @@
-import { addExtension } from '../../extensions/addExtension';
+import { setFirstClassOrExtension } from '../../extensions/setFirstClassOrExtension';
 import { findDrawMatchUp } from '@Acquire/findDrawMatchUp';
 
 import { DELEGATED_OUTCOME } from '@Constants/extensionConstants';
@@ -27,10 +27,10 @@ export function setDelegatedOutcome({ drawDefinition, matchUpId, outcome, matchU
     return { error: INVALID_VALUES };
   }
 
-  const extension = {
+  return setFirstClassOrExtension({
+    element: matchUp,
+    attribute: 'delegatedOutcome',
     name: DELEGATED_OUTCOME,
     value: outcome,
-  };
-
-  return addExtension({ element: matchUp, extension });
+  });
 }

--- a/src/mutate/drawDefinitions/positionGovernor/conditionallyDisableLinkPositioning.ts
+++ b/src/mutate/drawDefinitions/positionGovernor/conditionallyDisableLinkPositioning.ts
@@ -1,5 +1,5 @@
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 import { getPositionAssignments } from '@Query/drawDefinition/positionsGetter';
-import { addExtension } from '@Mutate/extensions/addExtension';
 
 // constants
 import { MAIN, QUALIFYING } from '@Constants/drawDefinitionConstants';
@@ -13,10 +13,11 @@ export function conditionallyDisableLinkPositioning({ drawPositions, structure }
   const { positionAssignments } = getPositionAssignments({ structure });
   const relevantAssignments = positionAssignments?.filter(({ drawPosition }) => drawPositions?.includes(drawPosition));
   relevantAssignments?.forEach((assignment) => {
-    const extension = {
+    setFirstClassOrExtension({
+      element: assignment,
+      attribute: 'disableLinks',
       name: DISABLE_LINKS,
       value: true,
-    };
-    addExtension({ element: assignment, extension });
+    });
   });
 }

--- a/src/mutate/drawDefinitions/resetDrawDefinition.ts
+++ b/src/mutate/drawDefinitions/resetDrawDefinition.ts
@@ -61,6 +61,8 @@ export function resetDrawDefinition({ tournamentRecord, removeScheduling, remove
   drawDefinition.extensions = drawDefinition.extensions.filter(
     (extension) => extension.name !== POSITION_ACTIONS && extension.name !== DRAFT_STATE,
   );
+  // CODES: also wipe the first-class draftState if present
+  delete drawDefinition.draftState;
 
   const structureIds = (drawDefinition.structures ?? []).map(({ structureId }) => structureId);
 

--- a/src/mutate/entries/addEventEntries.ts
+++ b/src/mutate/entries/addEventEntries.ts
@@ -1,10 +1,16 @@
-import { CategoryRejection, getEventDateRange, getParticipantName, validateParticipantCategory } from './categoryValidation';
+import {
+  CategoryRejection,
+  getEventDateRange,
+  getParticipantName,
+  validateParticipantCategory,
+} from './categoryValidation';
 import { isMatchUpEventType } from '@Helpers/matchUpEventTypes/isMatchUpEventType';
 import { getAppliedPolicies } from '@Query/extensions/getAppliedPolicies';
 import { addDrawEntries } from '@Mutate/drawDefinitions/addDrawEntries';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { refreshEntryPositions } from './refreshEntryPositions';
 import { isValidExtension } from '@Validators/isValidExtension';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 import { addExtension } from '@Mutate/extensions/addExtension';
 import { definedAttributes } from '@Tools/definedAttributes';
 import { removeEventEntries } from './removeEventEntries';
@@ -14,7 +20,15 @@ import { isMixed } from '@Validators/isMixed';
 import { isAny } from '@Validators/isAny';
 
 // constants and types
-import { DrawDefinition, EntryStatusUnion, Event, Extension, Participant, StageTypeUnion, Tournament } from '@Types/tournamentTypes';
+import {
+  DrawDefinition,
+  EntryStatusUnion,
+  Event,
+  Extension,
+  Participant,
+  StageTypeUnion,
+  Tournament,
+} from '@Types/tournamentTypes';
 import POLICY_MATCHUP_ACTIONS_DEFAULT from '@Fixtures/policies/POLICY_MATCHUP_ACTIONS_DEFAULT';
 import { DOUBLES_EVENT, HYBRID_EVENT, TEAM_EVENT } from '@Constants/eventConstants';
 import { INDIVIDUAL, PAIR, TEAM } from '@Constants/participantConstants';
@@ -195,7 +209,14 @@ function validateCompoundParticipantCategory(
     const individualParticipant = tournamentRecord.participants?.find((p) => p.participantId === individualId);
     if (!individualParticipant) continue;
 
-    const rejection = validateParticipantCategory(individualParticipant, event.category!, event, startDate, endDate, tournamentRecord);
+    const rejection = validateParticipantCategory(
+      individualParticipant,
+      event.category!,
+      event,
+      startDate,
+      endDate,
+      tournamentRecord,
+    );
     if (rejection) individualRejections.push(rejection);
   }
 
@@ -331,9 +352,11 @@ function createEntriesHelper({
       }
 
       if (roundTarget) {
-        addExtension({
-          extension: { name: ROUND_TARGET, value: roundTarget },
+        setFirstClassOrExtension({
           element: entry,
+          attribute: 'roundTarget',
+          name: ROUND_TARGET,
+          value: roundTarget,
         });
       }
       if (entryStageSequence) entry.entryStageSequence = entryStageSequence;

--- a/src/mutate/extensions/matchUps/disableTieAutoCalc.ts
+++ b/src/mutate/extensions/matchUps/disableTieAutoCalc.ts
@@ -1,4 +1,4 @@
-import { addExtension } from '../addExtension';
+import { setFirstClassOrExtension } from '../setFirstClassOrExtension';
 import { findDrawMatchUp } from '@Acquire/findDrawMatchUp';
 
 import { MISSING_DRAW_DEFINITION } from '@Constants/errorConditionConstants';
@@ -13,8 +13,10 @@ export function disableTieAutoCalc({ drawDefinition, matchUpId, event }) {
     event,
   });
 
-  return addExtension({
-    extension: { name: DISABLE_AUTO_CALC, value: true },
+  return setFirstClassOrExtension({
     element: matchUp,
+    attribute: 'disableAutoCalc',
+    name: DISABLE_AUTO_CALC,
+    value: true,
   });
 }

--- a/src/mutate/extensions/matchUps/removeDelegatedOutcome.ts
+++ b/src/mutate/extensions/matchUps/removeDelegatedOutcome.ts
@@ -1,6 +1,6 @@
+import { setFirstClassOrExtension } from '../setFirstClassOrExtension';
 import { requireParams } from '@Helpers/parameters/requireParams';
 import { findDrawMatchUp } from '@Acquire/findDrawMatchUp';
-import { removeExtension } from '../removeExtension';
 
 import { DRAW_DEFINITION, MATCHUP_ID } from '@Constants/attributeConstants';
 import { MATCHUP_NOT_FOUND } from '@Constants/errorConditionConstants';
@@ -13,8 +13,10 @@ export function removeDelegatedOutcome({ drawDefinition, event, matchUpId }) {
   const { matchUp } = findDrawMatchUp({ drawDefinition, event, matchUpId });
   if (!matchUp) return { error: MATCHUP_NOT_FOUND };
 
-  return removeExtension({
-    name: DELEGATED_OUTCOME,
+  return setFirstClassOrExtension({
     element: matchUp,
+    attribute: 'delegatedOutcome',
+    name: DELEGATED_OUTCOME,
+    value: undefined,
   });
 }

--- a/src/mutate/extensions/updateFactoryExtension.ts
+++ b/src/mutate/extensions/updateFactoryExtension.ts
@@ -1,22 +1,15 @@
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import { extensionConstants } from '@Constants/extensionConstants';
-import { addExtension } from '@Mutate/extensions/addExtension';
-import { findExtension } from '@Acquire/findExtension';
 
 const { FACTORY } = extensionConstants;
 
 export function updateFactoryExtension({ tournamentRecord, value }) {
-  const { extension } = findExtension({
+  const existing = firstClassOrExtension({ element: tournamentRecord, attribute: 'factory', name: FACTORY });
+  setFirstClassOrExtension({
     element: tournamentRecord,
+    attribute: 'factory',
     name: FACTORY,
+    value: { ...existing, ...value },
   });
-
-  const updatedExtension = {
-    name: FACTORY,
-    value: {
-      ...extension?.value,
-      ...value,
-    },
-  };
-
-  addExtension({ element: tournamentRecord, extension: updatedExtension });
 }

--- a/src/mutate/matchUps/drawPositions/positionUnseededParticipants.ts
+++ b/src/mutate/matchUps/drawPositions/positionUnseededParticipants.ts
@@ -5,7 +5,7 @@ import { assignDrawPosition } from '@Mutate/matchUps/drawPositions/positionAssig
 import { getAppliedPolicies } from '@Query/extensions/getAppliedPolicies';
 import { getStageEntries } from '@Query/drawDefinition/stageGetter';
 import { decorateResult } from '@Functions/global/decorateResult';
-import { findExtension } from '@Acquire/findExtension';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import { findStructure } from '@Acquire/findStructure';
 import { shuffleArray } from '@Tools/arrays';
 
@@ -50,7 +50,9 @@ export function positionUnseededParticipants({
   const { stage, stageSequence } = structure;
 
   const roundTarget =
-    stage === QUALIFYING ? findExtension({ element: structure, name: ROUND_TARGET })?.extension?.value : undefined;
+    stage === QUALIFYING
+      ? firstClassOrExtension({ element: structure, attribute: 'roundTarget', name: ROUND_TARGET })
+      : undefined;
 
   const entryStatuses = DIRECT_ENTRY_STATUSES;
   const entries = getStageEntries({

--- a/src/mutate/matchUps/matchUpStatus/setMatchUpState.ts
+++ b/src/mutate/matchUps/matchUpStatus/setMatchUpState.ts
@@ -12,15 +12,14 @@ import { swapWinnerLoser } from '@Mutate/matchUps/drawPositions/swapWinnerLoser'
 import { modifyMatchUpScore } from '@Mutate/matchUps/score/modifyMatchUpScore';
 import { ensureSideLineUps } from '@Mutate/matchUps/lineUps/ensureSideLineUps';
 import { getPositionAssignments } from '@Query/drawDefinition/positionsGetter';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 import { isActiveDownstream } from '@Query/drawDefinition/isActiveDownstream';
 import { getAppliedPolicies } from '@Query/extensions/getAppliedPolicies';
 import { checkScoreHasValue } from '@Query/matchUp/checkScoreHasValue';
-import { removeExtension } from '@Mutate/extensions/removeExtension';
 import { getAllDrawMatchUps } from '@Query/matchUps/drawMatchUps';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { positionTargets } from '@Query/matchUp/positionTargets';
 import { getMatchUpsMap } from '@Query/matchUps/getMatchUpsMap';
-import { addExtension } from '@Mutate/extensions/addExtension';
 import { pushGlobalLog } from '@Functions/global/globalLog';
 import { validateScore } from '@Validators/validateScore';
 import { findDrawMatchUp } from '@Acquire/findDrawMatchUp';
@@ -115,10 +114,26 @@ export function setMatchUpState(params: SetMatchUpStateArgs): any {
   const validationError = validateMatchUpStateInputs({ drawDefinition, matchUpStatus, winningSide });
   if (validationError) return validationError;
 
-  const resolved = resolveMatchUpAndContext({ tournamentRecord, drawDefinition, matchUpId, event, matchUpStatus, winningSide });
+  const resolved = resolveMatchUpAndContext({
+    tournamentRecord,
+    drawDefinition,
+    matchUpId,
+    event,
+    matchUpStatus,
+    winningSide,
+  });
   if (resolved.error) return resolved;
 
-  const { matchUp, inContextMatchUp, inContextDrawMatchUps, matchUpsMap, structure, isTeam, assignedDrawPositions, matchUpTieId } = resolved;
+  const {
+    matchUp,
+    inContextMatchUp,
+    inContextDrawMatchUps,
+    matchUpsMap,
+    structure,
+    isTeam,
+    assignedDrawPositions,
+    matchUpTieId,
+  } = resolved;
 
   const targetData = positionTargets({
     matchUpId: matchUpTieId || matchUpId,
@@ -344,7 +359,16 @@ function checkDownstreamCompatibility({ matchUpTieId, activeDownstream, matchUpS
 }
 
 function resolveAndApplyOutcome({ params, isTeam, dualWinningSideChange, activeDownstream, stack }) {
-  const { allowChangePropagation, tournamentRecords, tournamentRecord, drawDefinition, winningSide, matchUpId, matchUpTieId, matchUp } = params;
+  const {
+    allowChangePropagation,
+    tournamentRecords,
+    tournamentRecord,
+    drawDefinition,
+    winningSide,
+    matchUpId,
+    matchUpTieId,
+    matchUp,
+  } = params;
 
   const { schedule } = params;
   if (schedule) {
@@ -364,11 +388,7 @@ function resolveAndApplyOutcome({ params, isTeam, dualWinningSideChange, activeD
   const validWinningSideSwap =
     !isTeam && !dualWinningSideChange && winningSide && matchUp.winningSide && matchUp.winningSide !== winningSide;
 
-  if (
-    allowChangePropagation &&
-    validWinningSideSwap &&
-    matchUp.roundPosition
-  ) {
+  if (allowChangePropagation && validWinningSideSwap && matchUp.roundPosition) {
     return swapWinnerLoser(params);
   }
 
@@ -413,9 +433,11 @@ function handleTeamAutoCalc({
   let dualWinningSideChange;
 
   if (disableAutoCalc) {
-    addExtension({
-      extension: { name: DISABLE_AUTO_CALC, value: true },
+    setFirstClassOrExtension({
       element: matchUp,
+      attribute: 'disableAutoCalc',
+      name: DISABLE_AUTO_CALC,
+      value: true,
     });
   } else if (enableAutoCalc) {
     const existingDualMatchUpWinningSide = matchUp.winningSide;
@@ -450,7 +472,12 @@ function handleTeamAutoCalc({
       });
     }
 
-    removeExtension({ name: DISABLE_AUTO_CALC, element: matchUp });
+    setFirstClassOrExtension({
+      element: matchUp,
+      attribute: 'disableAutoCalc',
+      name: DISABLE_AUTO_CALC,
+      value: undefined,
+    });
 
     // setting these parameters will enable noDownStreamDependencies to attemptToSetWinningSide
     Object.assign(params, {

--- a/src/mutate/matchUps/score/updateTieMatchUpScore.ts
+++ b/src/mutate/matchUps/score/updateTieMatchUpScore.ts
@@ -1,13 +1,13 @@
 import { generateTieMatchUpScore } from '@Assemblies/generators/tieMatchUpScore/generateTieMatchUpScore';
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
 import { resolveTieFormat } from '@Query/hierarchical/tieFormats/resolveTieFormat';
 import { ensureSideLineUps } from '@Mutate/matchUps/lineUps/ensureSideLineUps';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import { modifyMatchUpScore } from '@Mutate/matchUps/score/modifyMatchUpScore';
 import { copyTieFormat } from '@Query/hierarchical/tieFormats/copyTieFormat';
-import { removeExtension } from '@Mutate/extensions/removeExtension';
 import { isActiveMatchUp } from '@Query/matchUp/activeMatchUp';
 import { findTournamentId } from '@Acquire/findTournamentId';
 import { findDrawMatchUp } from '@Acquire/findDrawMatchUp';
-import { findExtension } from '@Acquire/findExtension';
 
 // constants and types
 import { COMPLETED, completedMatchUpStatuses, IN_PROGRESS, TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
@@ -72,16 +72,22 @@ export function updateTieMatchUpScore(params: UpdateTieMatchUpScoreArgs): {
     drawDefinition,
   });
 
-  const { extension } = findExtension({
-    name: DISABLE_AUTO_CALC,
+  const disableAutoCalc = firstClassOrExtension({
     element: matchUp,
+    attribute: 'disableAutoCalc',
+    name: DISABLE_AUTO_CALC,
   });
 
-  if (extension?.value) {
+  if (disableAutoCalc) {
     if (!removeScore) {
       return { ...SUCCESS, score: matchUp.score };
     } else {
-      removeExtension({ element: matchUp, name: DISABLE_AUTO_CALC });
+      setFirstClassOrExtension({
+        element: matchUp,
+        attribute: 'disableAutoCalc',
+        name: DISABLE_AUTO_CALC,
+        value: undefined,
+      });
     }
   }
 

--- a/src/mutate/venues/disableCourts.ts
+++ b/src/mutate/venues/disableCourts.ts
@@ -1,6 +1,6 @@
+import { setFirstClassOrExtension } from '../extensions/setFirstClassOrExtension';
 import { resolveTournamentRecords } from '@Helpers/parameters/resolveTournamentRecords';
 import { checkRequiredParameters } from '@Helpers/parameters/checkRequiredParameters';
-import { addExtension } from '../extensions/addExtension';
 
 // constants
 import { COURT_IDS, TOURNAMENT_RECORDS } from '@Constants/attributeConstants';
@@ -31,10 +31,12 @@ export function disableCourts(params: DisableCourtsArgs) {
 function courtsDisable({ tournamentRecord, courtIds, dates }) {
   const disabledValue = Array.isArray(dates) && dates.length ? { dates } : true;
   const disableCourt = (court) =>
-    addExtension({
-      extension: { value: disabledValue, name: DISABLED },
-      creationTime: false,
+    setFirstClassOrExtension({
       element: court,
+      attribute: 'disabled',
+      name: DISABLED,
+      value: disabledValue,
+      creationTime: false,
     });
 
   for (const venue of tournamentRecord.venues ?? []) {

--- a/src/mutate/venues/disableVenues.ts
+++ b/src/mutate/venues/disableVenues.ts
@@ -1,5 +1,5 @@
+import { setFirstClassOrExtension } from '../extensions/setFirstClassOrExtension';
 import { checkRequiredParameters } from '@Helpers/parameters/checkRequiredParameters';
-import { addExtension } from '../extensions/addExtension';
 
 // constants
 import { TOURNAMENT_RECORDS, VENUE_IDS } from '@Constants/attributeConstants';
@@ -31,13 +31,12 @@ export function disableVenues(params: DisableVenuesArgs) {
 function venuesDisable({ tournamentRecord, venueIds }) {
   for (const venue of tournamentRecord.venues ?? []) {
     if (venueIds?.includes(venue.venueId)) {
-      const result = addExtension({
-        creationTime: false,
+      const result = setFirstClassOrExtension({
         element: venue,
-        extension: {
-          name: DISABLED,
-          value: true,
-        },
+        attribute: 'disabled',
+        name: DISABLED,
+        value: true,
+        creationTime: false,
       });
       if (result.error) return result;
     }

--- a/src/mutate/venues/enableCourts.ts
+++ b/src/mutate/venues/enableCourts.ts
@@ -1,8 +1,7 @@
+import { setFirstClassOrExtension } from '../extensions/setFirstClassOrExtension';
 import { resolveTournamentRecords } from '@Helpers/parameters/resolveTournamentRecords';
 import { checkRequiredParameters } from '@Helpers/parameters/checkRequiredParameters';
-import { removeExtension } from '../extensions/removeExtension';
-import { addExtension } from '../extensions/addExtension';
-import { findExtension } from '@Acquire/findExtension';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 
 // constants
 import { COURT_IDS, TOURNAMENT_RECORDS } from '@Constants/attributeConstants';
@@ -29,24 +28,22 @@ function courtsEnable({ tournamentRecord, courtIds, enableAll, dates }) {
     for (const court of venue.courts ?? []) {
       if (enableAll || courtIds?.includes(court.courtId))
         if (Array.isArray(dates)) {
-          const { extension } = findExtension({
-            element: court,
-            name: DISABLED,
-          });
+          const value = firstClassOrExtension({ element: court, attribute: 'disabled', name: DISABLED });
 
-          if (extension) {
-            const value = extension.value;
+          if (value) {
             if (Array.isArray(value.dates)) {
               value.dates = value.dates.filter((date) => !dates.includes(date));
             }
-            addExtension({
-              extension: { name: DISABLED, value },
-              creationTime: false,
+            setFirstClassOrExtension({
               element: court,
+              attribute: 'disabled',
+              name: DISABLED,
+              value,
+              creationTime: false,
             });
           }
         } else {
-          removeExtension({ element: court, name: DISABLED });
+          setFirstClassOrExtension({ element: court, attribute: 'disabled', name: DISABLED, value: undefined });
         }
     }
   }

--- a/src/mutate/venues/enableVenues.ts
+++ b/src/mutate/venues/enableVenues.ts
@@ -1,6 +1,6 @@
+import { setFirstClassOrExtension } from '../extensions/setFirstClassOrExtension';
 import { resolveTournamentRecords } from '@Helpers/parameters/resolveTournamentRecords';
 import { checkRequiredParameters } from '@Helpers/parameters/checkRequiredParameters';
-import { removeExtension } from '../extensions/removeExtension';
 
 // constants and types
 import { TOURNAMENT_RECORDS, VENUE_IDS } from '@Constants/attributeConstants';
@@ -24,7 +24,8 @@ export function enableVenues(params: EnableVenuesArgs) {
   const { venueIds, enableAll } = params;
   for (const tournamentRecord of Object.values(tournamentRecords)) {
     for (const venue of tournamentRecord.venues ?? []) {
-      if (enableAll || venueIds?.includes(venue.venueId)) removeExtension({ element: venue, name: DISABLED });
+      if (enableAll || venueIds?.includes(venue.venueId))
+        setFirstClassOrExtension({ element: venue, attribute: 'disabled', name: DISABLED, value: undefined });
     }
   }
 

--- a/src/query/drawDefinition/competition/getCompetitionState.ts
+++ b/src/query/drawDefinition/competition/getCompetitionState.ts
@@ -1,5 +1,5 @@
 // Acquire
-import { findExtension } from '@Acquire/findExtension';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 
 // Constants
 import { COMPETITION_STATE } from '@Constants/extensionConstants';
@@ -18,6 +18,10 @@ type GetCompetitionStateResult = ResultType & {
 };
 
 export function getCompetitionState({ drawDefinition }: GetCompetitionStateArgs): GetCompetitionStateResult {
-  const { extension } = findExtension({ element: drawDefinition, name: COMPETITION_STATE });
-  return { competitionState: extension?.value as CompetitionState | undefined };
+  const competitionState = firstClassOrExtension({
+    element: drawDefinition,
+    attribute: 'competitionState',
+    name: COMPETITION_STATE,
+  });
+  return { competitionState: competitionState as CompetitionState | undefined };
 }

--- a/src/query/drawDefinition/draft/getDraftState.ts
+++ b/src/query/drawDefinition/draft/getDraftState.ts
@@ -1,4 +1,4 @@
-import { findExtension } from '@Acquire/findExtension';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 
 // constants and types
 import { MISSING_DRAW_DEFINITION, NOT_FOUND } from '@Constants/errorConditionConstants';
@@ -13,10 +13,8 @@ type GetDraftStateArgs = {
 export function getDraftState({ drawDefinition }: GetDraftStateArgs) {
   if (!drawDefinition) return { error: MISSING_DRAW_DEFINITION };
 
-  const { extension } = findExtension({ element: drawDefinition, name: DRAFT_STATE });
-  if (!extension?.value) return { error: NOT_FOUND, info: 'No draft found' };
-
-  const draftState = extension.value;
+  const draftState = firstClassOrExtension({ element: drawDefinition, attribute: 'draftState', name: DRAFT_STATE });
+  if (!draftState) return { error: NOT_FOUND, info: 'No draft found' };
 
   // compute summary stats
   const totalParticipants = draftState.tiers?.reduce(

--- a/src/query/drawDefinition/stageGetter.ts
+++ b/src/query/drawDefinition/stageGetter.ts
@@ -4,7 +4,6 @@ import { getBestFinishers } from '@Query/drawDefinition/getBestFinishers';
 
 // Acquire
 import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
-import { findExtension } from '@Acquire/findExtension';
 import { findStructure } from '@Acquire/findStructure';
 
 // Helpers
@@ -82,10 +81,7 @@ export function getStageEntries({
 }: GetStageEntriesArgs) {
   const entries =
     drawDefinition.entries?.reduce((entries: any[], entry) => {
-      const entryRoundTarget = findExtension({
-        name: ROUND_TARGET,
-        element: entry,
-      })?.extension?.value;
+      const entryRoundTarget = firstClassOrExtension({ element: entry, attribute: 'roundTarget', name: ROUND_TARGET });
       const stageTarget =
         (stage && entry.entryStage === stage) ||
         (stages?.length && entry.entryStage && stages.includes(entry.entryStage));

--- a/src/query/extensions/getDisabledStatus.ts
+++ b/src/query/extensions/getDisabledStatus.ts
@@ -2,20 +2,25 @@ import { isObject } from '@Tools/objects';
 
 type GetDisabledStatusArgs = {
   dates?: string[];
+  // CODES: accept either the raw stored value (first-class) or the legacy
+  // extension wrapper. Callers should pass `disabledValue` directly via
+  // firstClassOrExtension; `extension` is retained for back-compat.
+  disabledValue?: any;
   extension?: any;
 };
 
-export function getDisabledStatus({ dates = [], extension }: GetDisabledStatusArgs) {
-  if (!extension) return false;
+export function getDisabledStatus({ dates = [], disabledValue, extension }: GetDisabledStatusArgs) {
+  const value = disabledValue !== undefined ? disabledValue : extension?.value;
+  if (value === undefined) return false;
 
-  // boolean value false means court is entirely disabled
-  if (typeof extension.value === 'boolean' && extension.value) return true;
+  // boolean value true means court is entirely disabled
+  if (typeof value === 'boolean' && value) return true;
   // even if a court is disabled for specific dates, if no dates are provided then it is not considered disabled
   // REFINEMENT: if disabledDates include all dates from tournament.startDate to tournament.endDate then court is disabled
 
   if (!dates.length) return false;
 
-  const disabledDates = isObject(extension.value) ? extension.value?.dates : undefined;
+  const disabledDates = isObject(value) ? value?.dates : undefined;
 
   if (Array.isArray(disabledDates)) {
     if (!disabledDates?.length) return false;

--- a/src/query/matchUps/getTargetMatchUp.ts
+++ b/src/query/matchUps/getTargetMatchUp.ts
@@ -2,7 +2,7 @@ import { getPositionAssignments } from '../drawDefinition/positionsGetter';
 import { chunkArray, generateRange } from '@Tools/arrays';
 import { getDevContext } from '@Global/state/globalState';
 import { reduceGroupedOrder } from './reduceGroupedOrder';
-import { findExtension } from '@Acquire/findExtension';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import { findStructure } from '@Acquire/findStructure';
 
 // constants
@@ -127,11 +127,12 @@ export function getTargetMatchUp({
 
   const relevantAssignment = positionAssignments?.find(({ drawPosition }) => drawPosition === targetDrawPosition);
   if (relevantAssignment) {
-    const { extension } = findExtension({
+    const disableLinks = firstClassOrExtension({
       element: relevantAssignment,
+      attribute: 'disableLinks',
       name: DISABLE_LINKS,
     });
-    if (extension?.value) {
+    if (disableLinks) {
       return { disabledDrawPosition: targetDrawPosition };
     }
   }

--- a/src/query/venues/getInContextCourt.ts
+++ b/src/query/venues/getInContextCourt.ts
@@ -1,6 +1,6 @@
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import { applyVenueConstraints } from './applyVenueConstraints';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
-import { findExtension } from '@Acquire/findExtension';
 import { isObject } from '@Tools/objects';
 
 import { DISABLED } from '@Constants/extensionConstants';
@@ -10,16 +10,13 @@ export function getInContextCourt({ convertExtensions, ignoreDisabled, venue, co
     ...makeDeepCopy(court, convertExtensions, true),
     venueId: venue.venueId,
   };
-  const { extension } = findExtension({
-    name: DISABLED,
-    element: court,
-  });
+  const disabledValue = firstClassOrExtension({ element: court, attribute: 'disabled', name: DISABLED });
 
-  if (ignoreDisabled && extension) {
-    const disabledDates = isObject(extension.value) ? extension.value?.dates : undefined;
+  if (ignoreDisabled && disabledValue !== undefined) {
+    const disabledDates = isObject(disabledValue) ? disabledValue?.dates : undefined;
 
     const dateAvailability =
-      extension?.value === true
+      disabledValue === true
         ? []
         : inContextCourt.dateAvailability
             .map((availability) => {

--- a/src/query/venues/venuesAndCourtsGetter.ts
+++ b/src/query/venues/venuesAndCourtsGetter.ts
@@ -1,6 +1,6 @@
 import { getDisabledStatus } from '@Query/extensions/getDisabledStatus';
 import { getInContextCourt } from './getInContextCourt';
-import { findExtension } from '@Acquire/findExtension';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
 
 // constants and types
@@ -23,11 +23,8 @@ type GetVenuesAndCourtsArgs = {
 function shouldIncludeVenue(venue: Venue, venueIds: string[], ignoreDisabled: boolean): boolean {
   if (venueIds.length && !venueIds.includes(venue.venueId)) return false;
   if (ignoreDisabled) {
-    const { extension } = findExtension({
-      name: DISABLED,
-      element: venue,
-    });
-    if (extension?.value) return false;
+    const disabledValue = firstClassOrExtension({ element: venue, attribute: 'disabled', name: DISABLED });
+    if (disabledValue) return false;
   }
   return true;
 }
@@ -58,11 +55,8 @@ function processVenue({
   for (const court of venue.courts ?? []) {
     if (!uniqueCourtIds.includes(court.courtId)) {
       if (ignoreDisabled) {
-        const { extension } = findExtension({
-          name: DISABLED,
-          element: court,
-        });
-        const isDisabled = getDisabledStatus({ extension, dates });
+        const disabledValue = firstClassOrExtension({ element: court, attribute: 'disabled', name: DISABLED });
+        const isDisabled = getDisabledStatus({ disabledValue, dates });
         if (isDisabled) continue;
       }
       const { inContextCourt } = getInContextCourt({
@@ -138,11 +132,8 @@ export function getTournamentVenuesAndCourts({
   const venues = makeDeepCopy(tournamentRecord.venues ?? [], convertExtensions)
     .filter((venue) => {
       if (!ignoreDisabled) return venue;
-      const { extension } = findExtension({
-        name: DISABLED,
-        element: venue,
-      });
-      return !extension?.value && venue;
+      const disabledValue = firstClassOrExtension({ element: venue, attribute: 'disabled', name: DISABLED });
+      return !disabledValue && venue;
     })
     .filter(Boolean);
 
@@ -150,11 +141,8 @@ export function getTournamentVenuesAndCourts({
     const additionalCourts = (venue?.courts ?? [])
       .filter((court) => {
         if (!ignoreDisabled && !dates?.length) return court;
-        const { extension } = findExtension({
-          name: DISABLED,
-          element: court,
-        });
-        return getDisabledStatus({ extension, dates });
+        const disabledValue = firstClassOrExtension({ element: court, attribute: 'disabled', name: DISABLED });
+        return getDisabledStatus({ disabledValue, dates });
       })
       .filter(Boolean)
       .map((court) => {

--- a/src/tests/global/flatScalarsFirstClass.test.ts
+++ b/src/tests/global/flatScalarsFirstClass.test.ts
@@ -1,0 +1,94 @@
+/**
+ * CODES Phase 4 — first-class promotion of flat scalar / object extensions:
+ *   - `factory` (Tournament)
+ *   - `delegatedOutcome` (MatchUp)
+ *   - `disableAutoCalc` (MatchUp)
+ *   - `disableLinks` (PositionAssignment)
+ *   - `disabled` (Venue, Court)
+ *   - `roundTarget` (Entry, Structure)
+ *   - `draftState` (DrawDefinition)
+ *   - `competitionState` (DrawDefinition)
+ *
+ * `linkedTournamentIds` is intentionally NOT in Phase 4 — its legacy extension
+ * value is `{tournamentIds: string[]}` while the CODES first-class shape would
+ * be a flat `string[]`. That shape translation is deferred to Phase 7's
+ * `migrateTournamentRecord` utility.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { setFirstClassOrExtension } from '@Mutate/extensions/setFirstClassOrExtension';
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
+import { setSchemaWriteMode } from '@Global/state/globalState';
+import { findExtension } from '@Acquire/findExtension';
+
+// constants and types
+import { DUAL, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
+import {
+  COMPETITION_STATE,
+  DELEGATED_OUTCOME,
+  DISABLE_AUTO_CALC,
+  DISABLE_LINKS,
+  DISABLED,
+  DRAFT_STATE,
+  FACTORY,
+  ROUND_TARGET,
+} from '@Constants/extensionConstants';
+
+type Promotion = { name: string; attribute: string; value: any };
+
+const promotions: Promotion[] = [
+  { name: FACTORY, attribute: 'factory', value: { version: '5.0.0-alpha.0' } },
+  { name: DELEGATED_OUTCOME, attribute: 'delegatedOutcome', value: { winningSide: 1 } },
+  { name: DISABLE_AUTO_CALC, attribute: 'disableAutoCalc', value: true },
+  { name: DISABLE_LINKS, attribute: 'disableLinks', value: true },
+  { name: DISABLED, attribute: 'disabled', value: true },
+  { name: DISABLED, attribute: 'disabled', value: { dates: ['2026-01-05'] } },
+  { name: ROUND_TARGET, attribute: 'roundTarget', value: 2 },
+  { name: DRAFT_STATE, attribute: 'draftState', value: { status: 'COLLECTING_PREFERENCES' } },
+  { name: COMPETITION_STATE, attribute: 'competitionState', value: { roundStates: {} } },
+];
+
+describe.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('flat scalar routing (mode=%s)', (mode) => {
+  it.each(promotions)('$attribute', ({ name, attribute, value }) => {
+    setSchemaWriteMode(mode);
+    const element: any = {};
+    setFirstClassOrExtension({ element, attribute, name, value });
+
+    const ext = findExtension({ element, name }).extension;
+    if (mode === NATIVE) {
+      expect(element[attribute]).toEqual(value);
+      expect(ext).toBeUndefined();
+    } else if (mode === DUAL) {
+      expect(element[attribute]).toEqual(value);
+      expect(ext?.value).toEqual(value);
+    } else {
+      expect(element[attribute]).toBeUndefined();
+      expect(ext?.value).toEqual(value);
+    }
+  });
+});
+
+describe('Read symmetry', () => {
+  it.each(promotions)('mode-agnostic read for $attribute', ({ name, attribute, value }) => {
+    for (const mode of [NATIVE, DUAL, LEGACY] as SchemaWriteMode[]) {
+      setSchemaWriteMode(mode);
+      const element: any = {};
+      setFirstClassOrExtension({ element, attribute, name, value });
+      expect(firstClassOrExtension({ element, attribute, name })).toEqual(value);
+    }
+  });
+});
+
+describe('Undefined-value removal', () => {
+  it.each(promotions)('clears both surfaces for $attribute', ({ name, attribute, value }) => {
+    setSchemaWriteMode(DUAL);
+    const element: any = {};
+    setFirstClassOrExtension({ element, attribute, name, value });
+    expect(element[attribute]).toEqual(value);
+
+    setFirstClassOrExtension({ element, attribute, name, value: undefined });
+    expect(element[attribute]).toBeUndefined();
+    const ext = findExtension({ element, name }).extension;
+    expect(ext).toBeUndefined();
+  });
+});

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -6,6 +6,8 @@ export interface Tournament {
   endDate?: string;
   events?: Event[];
   extensions?: Extension[];
+  // CODES first-class: previously stored as `factory` extension (processor versioning)
+  factory?: { version?: string; [key: string]: any };
   formalName?: string;
   hostCountryCode?: CountryCodeUnion;
   indoorOutdoor?: IndoorOutdoorUnion;
@@ -183,6 +185,10 @@ export interface DrawDefinition {
   endDate?: string;
   entries?: Entry[];
   extensions?: Extension[];
+  // CODES first-class: previously stored as `competitionState` extension
+  competitionState?: any;
+  // CODES first-class: previously stored as `draftState` extension
+  draftState?: any;
   // CODES first-class: previously stored as `flightProfile` extension
   flightProfile?: any;
   isMock?: boolean;
@@ -215,6 +221,8 @@ export interface Entry {
   isMock?: boolean;
   notes?: string;
   participantId: string;
+  // CODES first-class: previously stored as `roundTarget` extension on entry
+  roundTarget?: number;
   timeItems?: TimeItem[];
   updatedAt?: Date | string;
   scaleValue?: number;
@@ -354,6 +362,10 @@ export interface MatchUp {
   collectionId?: string;
   collectionPosition?: number;
   createdAt?: Date | string;
+  // CODES first-class: previously stored as `delegatedOutcome` extension
+  delegatedOutcome?: any;
+  // CODES first-class: previously stored as `disableAutoCalc` extension (tie matchUp)
+  disableAutoCalc?: boolean;
   drawPositions?: number[];
   endDate?: string;
   extensions?: Extension[];
@@ -716,6 +728,8 @@ export interface Structure {
   qualifyingRoundNumber?: number;
   roundLimit?: number;
   roundOffset?: number;
+  // CODES first-class: previously stored as `roundTarget` extension (qualifying routing)
+  roundTarget?: number;
   seedAssignments?: SeedAssignment[];
   seedingProfile?: SeedingProfileUnion;
   seedLimit?: number;
@@ -779,6 +793,8 @@ export interface TallyResult {
 export interface PositionAssignment {
   bye?: boolean;
   createdAt?: Date | string;
+  // CODES first-class: previously stored as `disableLinks` extension
+  disableLinks?: boolean;
   drawPosition: number;
   extensions?: Extension[];
   isMock?: boolean;
@@ -1502,6 +1518,8 @@ export interface Venue {
   dateAvailability?: Availability[];
   defaultEndTime?: string;
   defaultStartTime?: string;
+  // CODES first-class: previously stored as `disabled` extension
+  disabled?: boolean | { dates?: string[] };
   extensions?: Extension[];
   isMock?: boolean;
   isPrimary?: boolean;
@@ -1526,6 +1544,8 @@ export interface Court {
   courtName?: string;
   createdAt?: Date | string;
   dateAvailability?: Availability[];
+  // CODES first-class: previously stored as `disabled` extension
+  disabled?: boolean | { dates?: string[] };
   extensions?: Extension[];
   floodlit?: boolean;
   indoorOutdoor?: IndoorOutdoorUnion;


### PR DESCRIPTION
## Summary

CODES Phase 4: promote 8 of 9 canonical flat-shape extensions to first-class typed attributes. `linkedTournamentIds` is deferred to Phase 7 — the legacy extension stores `{tournamentIds: string[]}` while the CODES shape is a flat `string[]`, and that translation belongs with the one-shot migration utility.

## Promoted

| Legacy extension | First-class attribute |
|---|---|
| `FACTORY` (Tournament) | `Tournament.factory: {version, [k]: any}` |
| `DELEGATED_OUTCOME` (MatchUp) | `MatchUp.delegatedOutcome` |
| `DISABLE_AUTO_CALC` (MatchUp) | `MatchUp.disableAutoCalc: boolean` |
| `DISABLE_LINKS` (PositionAssignment) | `PositionAssignment.disableLinks: boolean` |
| `DISABLED` (Venue / Court) | `Venue.disabled` / `Court.disabled: boolean \| {dates?: string[]}` |
| `ROUND_TARGET` (Entry / Structure) | `Entry.roundTarget` / `Structure.roundTarget: number` |
| `DRAFT_STATE` (DrawDefinition) | `DrawDefinition.draftState` |
| `COMPETITION_STATE` (DrawDefinition) | `DrawDefinition.competitionState` |

## Migrated (20 source files)

- Tournament: `updateFactoryExtension`
- MatchUp: `setDelegatedOutcome`, `removeDelegatedOutcome`, `disableTieAutoCalc`, `setMatchUpState`, `updateTieMatchUpScore`
- PositionAssignment: `conditionallyDisableLinkPositioning`, `getTargetMatchUp`
- Venue/Court: `disableCourts`, `disableVenues`, `enableCourts`, `enableVenues`, `getInContextCourt`, `venuesAndCourtsGetter`, `getDisabledStatus` (extended with `disabledValue` param for mode-agnostic reads)
- Entry/Structure: `addEventEntries`, `addDrawEntries`, `generateQualifyingStructure`, `generateQualifyingStructures`, `roundRobin`, `positionUnseededParticipants`, `findStructure`, `structureSort`, `stageGetter`
- DrawDefinition (draft): `initializeDraft`, `setDrawPositionPreferences`, `resolveDraftPositions`, `getDraftState`
- DrawDefinition (competition): `initializeCompetitionState`, `resetCompetitionState`, `processCompetitionMatchUp`, `processCompetitionRound`, `getCompetitionState`
- `resetDrawDefinition` — extended to clear first-class `drawDefinition.draftState` alongside the legacy extension filter

## Tests

- New `flatScalarsFirstClass.test.ts` — 45 tests covering every promotion across NATIVE / DUAL / LEGACY routing, read symmetry, and undefined-value removal
- Full factory suite: 918 files / 9529 pass / 7 skip / 0 fail (master baseline preserved)
- Lint + types green

## Breaking changes (v5.0.0-alpha)

In NATIVE mode (default), consumers reading raw `.extensions[]` for any of the 8 promoted names will find nothing. Migrate to reading the first-class attribute, or set `engine.schemaWriteMode('legacy'|'dual')` at startup.

## Test plan

- [ ] `pnpm check-types` green
- [ ] `pnpm lint` zero warnings
- [ ] `pnpm test --run` 918 files / 9529 pass / 7 skip