### PR TITLE
feat!: CODES Phase 5 — tournamentRecord.scheduling group leaf

### DIFF
--- a/src/assemblies/generators/tournamentRecords/anonymizeTournamentRecord.ts
+++ b/src/assemblies/generators/tournamentRecords/anonymizeTournamentRecord.ts
@@ -56,6 +56,15 @@ export function anonymizeTournamentRecord({
   return { ...SUCCESS };
 }
 
+function anonymizeSchedulingProfileRounds(rounds: any[], idMap: any) {
+  for (const round of rounds) {
+    round.tournamentId = idMap[round.tournamentId];
+    round.structureId = idMap[round.structureId];
+    round.eventId = idMap[round.eventId];
+    round.drawId = idMap[round.drawId];
+  }
+}
+
 function anonymizeFlightProfileFlights(flightProfile: any, idMap: any) {
   for (const flight of flightProfile.flights) {
     flight.drawId = idMap[flight.drawId];
@@ -414,12 +423,11 @@ function anonymizeExtensionIds({ tournamentRecord, idMap }) {
   });
 
   if (Array.isArray(schedulingProfile?.value)) {
-    schedulingProfile?.value.forEach((round) => {
-      round.tournamentId = idMap[round.tournamentId];
-      round.structureId = idMap[round.structureId];
-      round.eventId = idMap[round.eventId];
-      round.drawId = idMap[round.drawId];
-    });
+    anonymizeSchedulingProfileRounds(schedulingProfile.value, idMap);
+  }
+  // CODES: also anonymize the first-class `tournamentRecord.scheduling.profile`
+  if (Array.isArray(tournamentRecord.scheduling?.profile)) {
+    anonymizeSchedulingProfileRounds(tournamentRecord.scheduling.profile, idMap);
   }
 
   const { extension: personRequests } = findExtension({

--- a/src/mutate/extensions/matchUps/modifyMatchUpFormatTiming.ts
+++ b/src/mutate/extensions/matchUps/modifyMatchUpFormatTiming.ts
@@ -1,3 +1,4 @@
+import { firstClassGroupLeafOrExtension, setGroupLeafOrExtension } from '../setGroupLeafOrExtension';
 import { addExtension } from '../addExtension';
 import { findExtension } from '@Acquire/findExtension';
 import { findEvent } from '@Acquire/findEvent';
@@ -67,20 +68,26 @@ function modifyTiming({ tournamentRecord, recoveryTimes, matchUpFormat, averageT
     });
     addExtension({ element: event, extension: { name, value } });
   } else {
-    const { extension } = findExtension({
-      element: tournamentRecord,
-      name,
-    });
-    const tournamentScheduling = extension?.value ?? {};
+    // CODES: tournament-level SCHEDULE_TIMING → tournamentRecord.scheduling.timing
+    const tournamentScheduling =
+      firstClassGroupLeafOrExtension({
+        element: tournamentRecord,
+        groupAttribute: 'scheduling',
+        leafAttribute: 'timing',
+        name,
+      }) ?? {};
     const value = modifyScheduling({
       ...tournamentScheduling,
       matchUpFormat,
       averageTimes,
       recoveryTimes,
     });
-    addExtension({
-      extension: { name, value },
+    setGroupLeafOrExtension({
       element: tournamentRecord,
+      groupAttribute: 'scheduling',
+      leafAttribute: 'timing',
+      name,
+      value,
     });
   }
 

--- a/src/mutate/extensions/setGroupLeafOrExtension.ts
+++ b/src/mutate/extensions/setGroupLeafOrExtension.ts
@@ -1,0 +1,108 @@
+import { writeLegacyEnabled, writeNativeEnabled } from '@Global/state/globalState';
+import { decorateResult } from '@Functions/global/decorateResult';
+import { removeExtension } from './removeExtension';
+import { addExtension } from './addExtension';
+
+// constants and types
+import { ErrorType, INVALID_VALUES, MISSING_VALUE } from '@Constants/errorConditionConstants';
+import { SUCCESS } from '@Constants/resultConstants';
+
+type SetGroupLeafOrExtensionArgs = {
+  element: any;
+  groupAttribute: string;
+  leafAttribute: string;
+  name: string;
+  value: any;
+  creationTime?: boolean;
+};
+
+function writeNativeGroupLeaf(element: any, groupAttribute: string, leafAttribute: string, value: any) {
+  if (value === undefined || value === null) {
+    if (element[groupAttribute]) {
+      delete element[groupAttribute][leafAttribute];
+      if (Object.keys(element[groupAttribute]).length === 0) delete element[groupAttribute];
+    }
+    return;
+  }
+  if (!element[groupAttribute]) element[groupAttribute] = {};
+  element[groupAttribute][leafAttribute] = value;
+}
+
+function stripExtensionByName(element: any, name: string) {
+  if (Array.isArray(element.extensions) && element.extensions.some((ext: any) => ext?.name === name)) {
+    removeExtension({ element, name });
+  }
+}
+
+/**
+ * Write helper for the CODES schemaWriteMode transition (group-leaf variant).
+ *
+ * Promotes an extension to a nested first-class attribute path
+ * (`element[groupAttribute][leafAttribute] = value`) rather than a flat
+ * field. Used for cluster promotions like `tournamentRecord.scheduling.*`
+ * where related extensions (`schedulingProfile`, `scheduleLimits`,
+ * `scheduleTiming`) collapse onto a single group object.
+ *
+ * Mode semantics match {@link setFirstClassOrExtension}:
+ * - NATIVE: write the nested attribute; strip stale legacy extension; if
+ *   the group becomes empty, the group object is removed entirely.
+ * - DUAL: write both.
+ * - LEGACY: write only the extension.
+ *
+ * Read with `firstClassOrGroupLeafOrExtension` (or a per-site equivalent).
+ */
+export function setGroupLeafOrExtension(params?: SetGroupLeafOrExtensionArgs): {
+  success?: boolean;
+  error?: ErrorType;
+} {
+  const stack = 'setGroupLeafOrExtension';
+  if (typeof params !== 'object') return { error: MISSING_VALUE };
+  const { element, groupAttribute, leafAttribute, name, value, creationTime } = params;
+  if (!element || typeof element !== 'object') return decorateResult({ result: { error: INVALID_VALUES }, stack });
+  if (typeof groupAttribute !== 'string' || !groupAttribute)
+    return decorateResult({ result: { error: INVALID_VALUES }, stack });
+  if (typeof leafAttribute !== 'string' || !leafAttribute)
+    return decorateResult({ result: { error: INVALID_VALUES }, stack });
+  if (typeof name !== 'string' || !name) return decorateResult({ result: { error: INVALID_VALUES }, stack });
+
+  if (writeNativeEnabled()) {
+    writeNativeGroupLeaf(element, groupAttribute, leafAttribute, value);
+  }
+
+  if (writeLegacyEnabled()) {
+    if (value === undefined || value === null) {
+      removeExtension({ element, name });
+    } else {
+      const result = addExtension({ element, extension: { name, value }, creationTime });
+      if (result.error) return decorateResult({ result, stack });
+    }
+  } else {
+    stripExtensionByName(element, name);
+  }
+
+  return { ...SUCCESS };
+}
+
+type FirstClassGroupLeafOrExtensionArgs = {
+  element: any;
+  groupAttribute: string;
+  leafAttribute: string;
+  name: string;
+};
+
+/**
+ * Read helper paired with {@link setGroupLeafOrExtension}. Prefer
+ * `element[groupAttribute][leafAttribute]`; fall back to the legacy
+ * extension value.
+ */
+export function firstClassGroupLeafOrExtension({
+  element,
+  groupAttribute,
+  leafAttribute,
+  name,
+}: FirstClassGroupLeafOrExtensionArgs) {
+  const firstClass = element?.[groupAttribute]?.[leafAttribute];
+  if (firstClass !== undefined) return firstClass;
+  const ext = (element?.extensions ?? []).find((e: any) => e?.name === name);
+  return ext?.value;
+}

--- a/src/mutate/matchUps/schedule/addSchedulingProfileRound.ts
+++ b/src/mutate/matchUps/schedule/addSchedulingProfileRound.ts
@@ -1,8 +1,8 @@
+import { firstClassGroupLeafOrExtension } from '@Mutate/extensions/setGroupLeafOrExtension';
 import { getCompetitionDateRange } from '@Query/tournaments/getCompetitionDateRange';
 import { setSchedulingProfile } from '@Mutate/tournaments/schedulingProfile';
 import { decorateResult } from '@Functions/global/decorateResult';
 import { isValidDateString, sameDay } from '@Tools/dateTime';
-import { findExtension } from '@Acquire/findExtension';
 import { isObject } from '@Tools/objects';
 
 // constants
@@ -16,13 +16,18 @@ export function addSchedulingProfileRound({ tournamentRecords, scheduleDate, ven
   }
   const stack = 'addSchedulingProfileRound';
 
-  const { extension } = findExtension({
-    name: SCHEDULING_PROFILE,
-    tournamentRecords,
-    discover: true,
-  });
-
-  const schedulingProfile = extension?.value ?? [];
+  // CODES: prefer first-class scheduling.profile on any record; fall back to legacy extension
+  const schedulingProfile =
+    Object.values(tournamentRecords ?? {})
+      .map((record: any) =>
+        firstClassGroupLeafOrExtension({
+          element: record,
+          groupAttribute: 'scheduling',
+          leafAttribute: 'profile',
+          name: SCHEDULING_PROFILE,
+        }),
+      )
+      .find((p) => p !== undefined) ?? [];
   let dateProfile = schedulingProfile.find((dateProfile) => sameDay(scheduleDate, dateProfile.scheduleDate));
 
   if (!dateProfile) {

--- a/src/mutate/tournaments/schedulingProfile.ts
+++ b/src/mutate/tournaments/schedulingProfile.ts
@@ -1,10 +1,8 @@
+import { firstClassGroupLeafOrExtension, setGroupLeafOrExtension } from '../extensions/setGroupLeafOrExtension';
 import { getUpdatedSchedulingProfile } from '@Query/matchUps/scheduling/getUpdatedSchedulingProfile';
 import { validateSchedulingProfile } from '@Validators/validateSchedulingProfile';
 import { getCompetitionVenues } from '@Query/venues/venuesAndCourtsGetter';
-import { removeExtension } from '../extensions/removeExtension';
 import { getEventIdsAndDrawIds } from '@Query/tournaments/getEventIdsAndDrawIds';
-import { addExtension } from '../extensions/addExtension';
-import { findExtension } from '@Acquire/findExtension';
 
 import { ErrorType, MISSING_TOURNAMENT_RECORDS } from '@Constants/errorConditionConstants';
 import { SCHEDULING_PROFILE } from '@Constants/extensionConstants';
@@ -26,14 +24,24 @@ export function getSchedulingProfile({ tournamentRecords, tournamentRecord }: Ge
   if (typeof tournamentRecords !== 'object' || !Object.keys(tournamentRecords).length)
     return { error: MISSING_TOURNAMENT_RECORDS };
 
-  const { extension } = findExtension({
-    element: tournamentRecord, // if tournamentRecord is provided, use it
-    name: SCHEDULING_PROFILE,
-    tournamentRecords,
-    discover: true,
-  });
+  // CODES: prefer first-class `tournamentRecord.scheduling.profile`; fall back
+  // to the legacy extension. When tournamentRecord is not provided, discover
+  // across all records and use the first that carries either surface.
+  const resolveProfile = (record: Tournament | undefined) =>
+    record &&
+    firstClassGroupLeafOrExtension({
+      element: record,
+      groupAttribute: 'scheduling',
+      leafAttribute: 'profile',
+      name: SCHEDULING_PROFILE,
+    });
 
-  let schedulingProfile = extension?.value ?? [];
+  let schedulingProfile =
+    resolveProfile(tournamentRecord) ??
+    Object.values(tournamentRecords)
+      .map(resolveProfile)
+      .find((p) => p !== undefined) ??
+    [];
 
   if (schedulingProfile.length) {
     const { venueIds } = getCompetitionVenues({
@@ -82,20 +90,20 @@ export function setSchedulingProfile({
 
   if (profileValidity.error) return profileValidity;
 
-  if (!schedulingProfile)
-    return removeExtension({
-      element: tournamentRecord,
+  // CODES: apply to every tournamentRecord (discover semantics) using the
+  // group-leaf helper so writes land on `scheduling.profile` and / or the
+  // legacy `schedulingProfile` extension based on schemaWriteMode.
+  const targets = tournamentRecord ? [tournamentRecord] : Object.values(tournamentRecords ?? {});
+  for (const target of targets) {
+    setGroupLeafOrExtension({
+      element: target,
+      groupAttribute: 'scheduling',
+      leafAttribute: 'profile',
       name: SCHEDULING_PROFILE,
-      tournamentRecords,
-      discover: true,
+      value: schedulingProfile,
     });
-
-  const extension = {
-    name: SCHEDULING_PROFILE,
-    value: schedulingProfile,
-  };
-
-  return addExtension({ tournamentRecords, discover: true, extension });
+  }
+  return { ...SUCCESS };
 }
 
 export function checkAndUpdateSchedulingProfile(params) {

--- a/src/mutate/tournaments/setMatchUpDailyLimits.ts
+++ b/src/mutate/tournaments/setMatchUpDailyLimits.ts
@@ -1,4 +1,4 @@
-import { addExtension } from '@Mutate/extensions/addExtension';
+import { setGroupLeafOrExtension } from '@Mutate/extensions/setGroupLeafOrExtension';
 
 // constants and types
 import { INVALID_OBJECT, INVALID_VALUES, MISSING_TOURNAMENT_RECORDS } from '@Constants/errorConditionConstants';
@@ -35,9 +35,12 @@ export function setMatchUpDailyLimits(params: SetMatchUpDailyLimitsArgs): Result
 
   for (const currentTournamentId of tournamentIds) {
     const tournamentRecord = tournamentRecords[currentTournamentId];
-    const result = addExtension({
-      extension: { name: SCHEDULE_LIMITS, value: { dailyLimits } },
+    const result = setGroupLeafOrExtension({
       element: tournamentRecord,
+      groupAttribute: 'scheduling',
+      leafAttribute: 'dailyLimits',
+      name: SCHEDULE_LIMITS,
+      value: { dailyLimits },
     });
     if (result.error) return result;
   }

--- a/src/query/extensions/getMatchUpDailyLimits.ts
+++ b/src/query/extensions/getMatchUpDailyLimits.ts
@@ -1,5 +1,5 @@
+import { firstClassGroupLeafOrExtension } from '@Mutate/extensions/setGroupLeafOrExtension';
 import { checkRequiredParameters } from '@Helpers/parameters/checkRequiredParameters';
-import { findExtension } from '@Acquire/findExtension';
 
 // constants and types
 import { MISSING_TOURNAMENT_RECORDS } from '@Constants/errorConditionConstants';
@@ -49,12 +49,14 @@ export function getDailyLimit(params): ResultType & {
     tournamentRecord,
   });
 
-  const { extension } = findExtension({
+  const limitsValue = firstClassGroupLeafOrExtension({
     element: tournamentRecord,
+    groupAttribute: 'scheduling',
+    leafAttribute: 'dailyLimits',
     name: SCHEDULE_LIMITS,
   });
 
-  const tournamentDailyLimits = extension?.value?.dailyLimits;
+  const tournamentDailyLimits = limitsValue?.dailyLimits;
   const policyDailyLimits = policy?.defaultDailyLimits;
 
   return { matchUpDailyLimits: tournamentDailyLimits || policyDailyLimits };

--- a/src/query/extensions/matchUpFormatTiming/getModifiedMatchUpTiming.ts
+++ b/src/query/extensions/matchUpFormatTiming/getModifiedMatchUpTiming.ts
@@ -1,4 +1,5 @@
 import { findMatchupFormatAverageTimes, findMatchupFormatRecoveryTimes } from '@Acquire/findMatchUpFormatTimes';
+import { firstClassGroupLeafOrExtension } from '@Mutate/extensions/setGroupLeafOrExtension';
 import { checkRequiredParameters } from '@Helpers/parameters/checkRequiredParameters';
 import { isValidMatchUpFormat } from '@Validators/isValidMatchUpFormat';
 import { findExtension } from '@Acquire/findExtension';
@@ -39,11 +40,13 @@ export function getModifiedMatchUpFormatTiming(params: GetModifiedMatchUpFormatT
   });
   const eventScheduling = eventExtension?.value;
 
-  const { extension: tournamentExtension } = findExtension({
+  // CODES: tournament-level timing is now `tournamentRecord.scheduling.timing`
+  const tournamentScheduling = firstClassGroupLeafOrExtension({
     element: tournamentRecord,
+    groupAttribute: 'scheduling',
+    leafAttribute: 'timing',
     name: SCHEDULE_TIMING,
   });
-  const tournamentScheduling = tournamentExtension?.value;
 
   const eventAverageTimes =
     eventScheduling?.matchUpAverageTimes &&

--- a/src/query/extensions/matchUpFormatTiming/getScheduleTiming.ts
+++ b/src/query/extensions/matchUpFormatTiming/getScheduleTiming.ts
@@ -1,3 +1,4 @@
+import { firstClassGroupLeafOrExtension } from '@Mutate/extensions/setGroupLeafOrExtension';
 import { findExtension } from '@Acquire/findExtension';
 import { findPolicy } from '@Acquire/findPolicy';
 
@@ -22,13 +23,17 @@ export function getScheduleTiming({ tournamentRecord, categoryName, categoryType
     event,
   });
 
-  const tournamentExtension = tournamentRecord
-    ? findExtension({
+  // CODES: tournament-level scheduling timing has been promoted to
+  // `tournamentRecord.scheduling.timing` (group leaf). Event-level
+  // SCHEDULE_TIMING remains an extension.
+  const tournamentScheduling = tournamentRecord
+    ? firstClassGroupLeafOrExtension({
         element: tournamentRecord,
+        groupAttribute: 'scheduling',
+        leafAttribute: 'timing',
         name: SCHEDULE_TIMING,
-      }).extension
+      })
     : undefined;
-  const tournamentScheduling = tournamentExtension?.value;
 
   const eventExtension =
     event &&

--- a/src/tests/global/tournamentSchedulingFirstClass.test.ts
+++ b/src/tests/global/tournamentSchedulingFirstClass.test.ts
@@ -1,0 +1,140 @@
+/**
+ * CODES Phase 5 — tournamentRecord.scheduling group leaf.
+ *
+ * Three previously-separate tournament-level extensions collapse onto a
+ * single first-class object:
+ *
+ *   - `SCHEDULING_PROFILE`  → tournamentRecord.scheduling.profile
+ *   - `SCHEDULE_LIMITS`     → tournamentRecord.scheduling.dailyLimits
+ *   - `SCHEDULE_TIMING`     → tournamentRecord.scheduling.timing
+ *
+ * `SCHEDULE_TIMING` is also used at the event level (per-event matchUpFormat
+ * timing) — that promotion is NOT in Phase 5 scope and remains an extension
+ * on the Event entity.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { firstClassGroupLeafOrExtension, setGroupLeafOrExtension } from '@Mutate/extensions/setGroupLeafOrExtension';
+import { setSchemaWriteMode } from '@Global/state/globalState';
+import { findExtension } from '@Acquire/findExtension';
+
+// constants and types
+import { DUAL, LEGACY, NATIVE, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
+import { SCHEDULE_LIMITS, SCHEDULE_TIMING, SCHEDULING_PROFILE } from '@Constants/extensionConstants';
+
+type Promotion = { name: string; leaf: string; value: any };
+
+const promotions: Promotion[] = [
+  { name: SCHEDULING_PROFILE, leaf: 'profile', value: [{ scheduleDate: '2026-01-05', venues: [] }] },
+  { name: SCHEDULE_LIMITS, leaf: 'dailyLimits', value: { dailyLimits: { default: 3 } } },
+  {
+    name: SCHEDULE_TIMING,
+    leaf: 'timing',
+    value: { matchUpAverageTimes: [{ matchUpFormat: 'SET3-S:6/TB7', minutes: 60 }] },
+  },
+];
+
+describe.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])('scheduling group-leaf routing (mode=%s)', (mode) => {
+  it.each(promotions)('$leaf routes correctly', ({ name, leaf, value }) => {
+    setSchemaWriteMode(mode);
+    const tournamentRecord: any = { tournamentId: 't1' };
+
+    setGroupLeafOrExtension({
+      element: tournamentRecord,
+      groupAttribute: 'scheduling',
+      leafAttribute: leaf,
+      name,
+      value,
+    });
+
+    const fc = tournamentRecord.scheduling?.[leaf];
+    const ext = findExtension({ element: tournamentRecord, name }).extension;
+    if (mode === NATIVE) {
+      expect(fc).toEqual(value);
+      expect(ext).toBeUndefined();
+    } else if (mode === DUAL) {
+      expect(fc).toEqual(value);
+      expect(ext?.value).toEqual(value);
+    } else {
+      expect(tournamentRecord.scheduling).toBeUndefined();
+      expect(ext?.value).toEqual(value);
+    }
+  });
+});
+
+describe('Read symmetry — firstClassGroupLeafOrExtension', () => {
+  it.each(promotions)('mode-agnostic read for $leaf', ({ name, leaf, value }) => {
+    for (const mode of [NATIVE, DUAL, LEGACY] as SchemaWriteMode[]) {
+      setSchemaWriteMode(mode);
+      const tournamentRecord: any = { tournamentId: 't1' };
+      setGroupLeafOrExtension({
+        element: tournamentRecord,
+        groupAttribute: 'scheduling',
+        leafAttribute: leaf,
+        name,
+        value,
+      });
+      const read = firstClassGroupLeafOrExtension({
+        element: tournamentRecord,
+        groupAttribute: 'scheduling',
+        leafAttribute: leaf,
+        name,
+      });
+      expect(read).toEqual(value);
+    }
+  });
+});
+
+describe('Group bookkeeping', () => {
+  it('removes the group when the last leaf is cleared (NATIVE)', () => {
+    setSchemaWriteMode(NATIVE);
+    const tournamentRecord: any = { tournamentId: 't1' };
+    setGroupLeafOrExtension({
+      element: tournamentRecord,
+      groupAttribute: 'scheduling',
+      leafAttribute: 'profile',
+      name: SCHEDULING_PROFILE,
+      value: [{ scheduleDate: '2026-01-05', venues: [] }],
+    });
+    expect(tournamentRecord.scheduling?.profile).toBeDefined();
+
+    setGroupLeafOrExtension({
+      element: tournamentRecord,
+      groupAttribute: 'scheduling',
+      leafAttribute: 'profile',
+      name: SCHEDULING_PROFILE,
+      value: undefined,
+    });
+    expect(tournamentRecord.scheduling).toBeUndefined();
+  });
+
+  it('keeps the group when other leaves are still present (NATIVE)', () => {
+    setSchemaWriteMode(NATIVE);
+    const tournamentRecord: any = { tournamentId: 't1' };
+    setGroupLeafOrExtension({
+      element: tournamentRecord,
+      groupAttribute: 'scheduling',
+      leafAttribute: 'profile',
+      name: SCHEDULING_PROFILE,
+      value: [{ scheduleDate: '2026-01-05', venues: [] }],
+    });
+    setGroupLeafOrExtension({
+      element: tournamentRecord,
+      groupAttribute: 'scheduling',
+      leafAttribute: 'dailyLimits',
+      name: SCHEDULE_LIMITS,
+      value: { dailyLimits: { default: 3 } },
+    });
+
+    // Clear profile
+    setGroupLeafOrExtension({
+      element: tournamentRecord,
+      groupAttribute: 'scheduling',
+      leafAttribute: 'profile',
+      name: SCHEDULING_PROFILE,
+      value: undefined,
+    });
+    expect(tournamentRecord.scheduling?.dailyLimits).toEqual({ dailyLimits: { default: 3 } });
+    expect(tournamentRecord.scheduling?.profile).toBeUndefined();
+  });
+});

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -22,6 +22,14 @@ export interface Tournament {
   processCodes?: string[];
   promotionalName?: string;
   registrationProfile?: RegistrationProfile;
+  // CODES first-class group leaf: previously stored as separate
+  // `schedulingProfile`, `scheduleLimits`, and `scheduleTiming` extensions.
+  scheduling?: {
+    profile?: any;
+    dailyLimits?: any;
+    timing?: any;
+    [key: string]: any;
+  };
   season?: string;
   startDate?: string;
   surfaceCategory?: SurfaceCategoryUnion;


### PR DESCRIPTION
## Summary

CODES Phase 5: collapse three tournament-level scheduling extensions onto a single first-class group object — the only group leaf in the CODES migration where multiple related extensions cluster under a shared parent.

| Legacy extension | First-class path |
|---|---|
| `SCHEDULING_PROFILE` | `tournamentRecord.scheduling.profile` |
| `SCHEDULE_LIMITS` | `tournamentRecord.scheduling.dailyLimits` |
| `SCHEDULE_TIMING` | `tournamentRecord.scheduling.timing` |

`SCHEDULE_TIMING` is also used at the Event level (per-event matchUp format timing) — that promotion is intentionally NOT in Phase 5 scope and remains a plain extension on Event. The dual-target writer (`modifyMatchUpFormatTiming`) keeps the event branch on `addExtension` and routes only the tournament branch through the new group-leaf helper.

## New helpers

- `setGroupLeafOrExtension` — mode-aware writer; NATIVE writes the nested path and removes the group if it becomes empty; DUAL writes both surfaces; LEGACY writes only the extension
- `firstClassGroupLeafOrExtension` — paired read helper

## Migrated writers

- `setSchedulingProfile` (rewritten to iterate `tournamentRecords` rather than relying on `addExtension({discover:true})`)
- `setMatchUpDailyLimits`
- `modifyMatchUpFormatTiming` (tournament branch only)

## Migrated readers

- `getSchedulingProfile`, `addSchedulingProfileRound` (discover first-class first, extension fallback)
- `getMatchUpDailyLimits`
- `getScheduleTiming`
- `getModifiedMatchUpFormatTiming`

`anonymizeTournamentRecord` now walks both `tournamentRecord.scheduling.profile` and the legacy extension via an extracted `anonymizeSchedulingProfileRounds` helper.

## Tests

- New `tournamentSchedulingFirstClass.test.ts` — 14 tests covering each promoted leaf across NATIVE / DUAL / LEGACY, mode-agnostic reads, empty-group cleanup, partial-leaf preservation
- **Full factory suite: 920 files / 9588 pass / 7 skip / 0 fail** (Phase 4 baseline 918/9529: +2 files, +59 tests, zero regressions)
- Lint + types green

## Breaking changes (v5.0.0-alpha)

In NATIVE mode (default) consumers reading raw `tournamentRecord.extensions[]` for `SCHEDULING_PROFILE`, `SCHEDULE_LIMITS`, or tournament-level `SCHEDULE_TIMING` will find nothing. Read `tournamentRecord.scheduling.profile / .dailyLimits / .timing` directly, or use `firstClassGroupLeafOrExtension` for mode-agnostic reads, or set `engine.schemaWriteMode('legacy'|'dual')`.

## Test plan

- [ ] `pnpm check-types` green
- [ ] `pnpm lint` zero warnings
- [ ] `pnpm test --run` 920 files / 9588 pass / 7 skip