### PR TITLE
feat!: drawDeletions opt-in + server-authoritative gating (CODES Phase 6)

### DIFF
--- a/src/assemblies/engines/parts/engineStart.ts
+++ b/src/assemblies/engines/parts/engineStart.ts
@@ -8,6 +8,10 @@ import {
   getDevContext,
   setSchemaWriteMode,
   getSchemaWriteMode,
+  setSaveDrawDeletions,
+  getSaveDrawDeletions,
+  setAuditAuthorityServer,
+  getAuditAuthorityServer,
   removeTournamentRecord,
   setTournamentRecords,
   setTournamentId,
@@ -49,6 +53,16 @@ export function engineStart(engine: FactoryEngine, engineInvoke: any): void {
     return processResult(engine, result);
   };
   engine.getSchemaWriteMode = () => getSchemaWriteMode();
+  engine.saveDrawDeletions = (flag) => {
+    const result = setSaveDrawDeletions(flag);
+    return processResult(engine, result);
+  };
+  engine.getSaveDrawDeletions = () => getSaveDrawDeletions();
+  engine.auditAuthorityServer = (flag) => {
+    const result = setAuditAuthorityServer(flag);
+    return processResult(engine, result);
+  };
+  engine.getAuditAuthorityServer = () => getAuditAuthorityServer();
   engine.newTournamentRecord = (params = {}) => {
     const result = createTournamentRecord(params);
     const tournamentId = result.tournamentId;

--- a/src/global/state/globalState.ts
+++ b/src/global/state/globalState.ts
@@ -54,6 +54,8 @@ type GlobalStateTypes = {
   deepCopyAttributes: DeepCopyType;
   devContext?: DevContextType; // devContext is used to control logging
   schemaWriteMode: SchemaWriteMode; // controls extension vs first-class write behavior
+  saveDrawDeletions: boolean; // opt-in: persist drawDeletions audit on the record
+  auditAuthorityServer: boolean; // true on server engines — suppresses local audit writes
   timers: timersType; // timers are used to track elapsed time for methods
   deepCopy: boolean;
   globalLog?: any;
@@ -79,6 +81,8 @@ const globalState: GlobalStateTypes = {
   },
   globalMethods: [],
   schemaWriteMode: NATIVE,
+  saveDrawDeletions: false,
+  auditAuthorityServer: false,
   deepCopy: true,
 };
 
@@ -243,6 +247,34 @@ export function writeNativeEnabled(): boolean {
 
 export function writeLegacyEnabled(): boolean {
   return globalState.schemaWriteMode === LEGACY || globalState.schemaWriteMode === DUAL;
+}
+
+export function setSaveDrawDeletions(flag?: boolean): { success?: boolean; error?: ErrorType } {
+  if (flag === undefined) {
+    globalState.saveDrawDeletions = false;
+    return { ...SUCCESS };
+  }
+  if (typeof flag !== 'boolean') return { error: INVALID_VALUES };
+  globalState.saveDrawDeletions = flag;
+  return { ...SUCCESS };
+}
+
+export function getSaveDrawDeletions(): boolean {
+  return globalState.saveDrawDeletions;
+}
+
+export function setAuditAuthorityServer(flag?: boolean): { success?: boolean; error?: ErrorType } {
+  if (flag === undefined) {
+    globalState.auditAuthorityServer = false;
+    return { ...SUCCESS };
+  }
+  if (typeof flag !== 'boolean') return { error: INVALID_VALUES };
+  globalState.auditAuthorityServer = flag;
+  return { ...SUCCESS };
+}
+
+export function getAuditAuthorityServer(): boolean {
+  return globalState.auditAuthorityServer;
 }
 
 export function disableNotifications() {

--- a/src/mutate/events/deleteDrawDefinitions.ts
+++ b/src/mutate/events/deleteDrawDefinitions.ts
@@ -8,7 +8,7 @@ import { checkScoreHasValue } from '@Query/matchUp/checkScoreHasValue';
 import { modifyEventPublishStatus } from './modifyEventPublishStatus';
 import { allDrawMatchUps } from '@Query/matchUps/getAllDrawMatchUps';
 import { decorateResult } from '@Functions/global/decorateResult';
-import { addNotice, hasTopic } from '@Global/state/globalState';
+import { addNotice, getAuditAuthorityServer, getSaveDrawDeletions, hasTopic } from '@Global/state/globalState';
 import { getFlightProfile } from '@Query/event/getFlightProfile';
 import { addTimeItem } from '@Mutate/timeItems/addTimeItem';
 import { definedAttributes } from '@Tools/definedAttributes';
@@ -227,15 +227,14 @@ export function deleteDrawDefinitions(params: DeleteDrawDefinitionArgs) {
   }
 
   if (auditTrail.length) {
-    if (hasTopic(AUDIT)) {
-      const tournamentId = tournamentRecord.tournamentId;
-      addNotice({ topic: AUDIT, payload: { tournamentId, detail: auditTrail } });
-      const result = getTimeItem({ element: event, itemType: DRAW_DELETIONS });
-      const itemValue = (result?.timeItem?.itemValue || 0) + 1;
-      addTimeItem({ element: event, timeItem: { itemType: DRAW_DELETIONS, itemValue }, removePriorValues: true });
-    } else {
-      addDrawDeletionTelemetry({ appliedPolicies, event, deletedDrawsDetail, auditData });
-    }
+    dispatchDrawDeletionAudit({
+      tournamentId: tournamentRecord.tournamentId,
+      deletedDrawsDetail,
+      appliedPolicies,
+      auditTrail,
+      auditData,
+      event,
+    });
   }
   if (matchUpIds.length) {
     deleteMatchUpsNotice({
@@ -258,6 +257,33 @@ export function deleteDrawDefinitions(params: DeleteDrawDefinitionArgs) {
   }
 
   return { ...SUCCESS };
+}
+
+function dispatchDrawDeletionAudit({
+  tournamentId,
+  deletedDrawsDetail,
+  appliedPolicies,
+  auditTrail,
+  auditData,
+  event,
+}) {
+  // Always dispatch the AUDIT notice so subscribers (notably the server's
+  // AuditService when auditAuthorityServer is set) can capture the detail.
+  const subscribed = hasTopic(AUDIT);
+  if (subscribed) {
+    addNotice({ topic: AUDIT, payload: { tournamentId, detail: auditTrail } });
+  }
+  // Suppress all local writes when the server is the audit authority or
+  // saveDrawDeletions is off (default in 5.0.0).
+  if (getAuditAuthorityServer() || !getSaveDrawDeletions()) return;
+
+  if (subscribed) {
+    const result = getTimeItem({ element: event, itemType: DRAW_DELETIONS });
+    const itemValue = (result?.timeItem?.itemValue || 0) + 1;
+    addTimeItem({ element: event, timeItem: { itemType: DRAW_DELETIONS, itemValue }, removePriorValues: true });
+  } else {
+    addDrawDeletionTelemetry({ appliedPolicies, event, deletedDrawsDetail, auditData });
+  }
 }
 
 function addDrawDeletionTelemetry({ appliedPolicies, event, deletedDrawsDetail, auditData }) {

--- a/src/tests/global/drawDeletionsGating.test.ts
+++ b/src/tests/global/drawDeletionsGating.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { setAuditAuthorityServer, setSaveDrawDeletions, setSubscriptions } from '@Global/state/globalState';
+import mocksEngine from '@Assemblies/engines/mock';
+import { findExtension } from '@Acquire/findExtension';
+import tournamentEngine from '@Engines/syncEngine';
+import { getTimeItem } from '@Query/base/timeItems';
+
+// constants
+import { DELETE_DRAW_DEFINITIONS } from '@Constants/auditConstants';
+import { APPLIED_POLICIES, DRAW_DELETIONS } from '@Constants/extensionConstants';
+import { AUDIT } from '@Constants/topicConstants';
+
+const DRAW_PROFILES = [{ participantsCount: 30, drawSize: 32 }];
+
+function seedTournament() {
+  const result = mocksEngine.generateTournamentRecord({
+    inContext: true,
+    setState: true,
+    drawProfiles: DRAW_PROFILES,
+  });
+  return { drawId: result.drawIds[0], eventId: result.eventIds[0] };
+}
+
+afterEach(() => {
+  // remove any AUDIT subscription added during the test so the next test
+  // starts with the topic genuinely absent
+  setSubscriptions({ subscriptions: { [AUDIT]: true } });
+});
+
+describe('Phase 6 drawDeletions gating', () => {
+  it('auditAuthorityServer=true suppresses extension and timeItem even with AUDIT subscriber', () => {
+    setAuditAuthorityServer(true);
+    setSaveDrawDeletions(true);
+
+    let noticeCount = 0;
+    setSubscriptions({
+      subscriptions: {
+        [AUDIT]: (notices) => {
+          noticeCount += 1;
+          expect(notices[0].detail[0].action).toEqual(DELETE_DRAW_DEFINITIONS);
+          expect(notices[0].detail[0].payload.drawDefinitions).not.toBeUndefined();
+        },
+      },
+    });
+
+    const { drawId, eventId } = seedTournament();
+    const result = tournamentEngine.deleteDrawDefinitions({ drawIds: [drawId], eventId });
+    expect(result.success).toEqual(true);
+
+    const { event } = tournamentEngine.getEvent({ drawId });
+    const { extension } = findExtension({ name: DRAW_DELETIONS, element: event });
+    expect(extension).toBeUndefined();
+    const { timeItem } = getTimeItem({ element: event, itemType: DRAW_DELETIONS });
+    expect(timeItem).toBeUndefined();
+    expect(noticeCount).toEqual(1);
+  });
+
+  it('auditAuthorityServer=true with no AUDIT subscriber writes nothing to the record', () => {
+    setAuditAuthorityServer(true);
+    setSaveDrawDeletions(true);
+
+    const { drawId, eventId } = seedTournament();
+    const result = tournamentEngine.deleteDrawDefinitions({ drawIds: [drawId], eventId });
+    expect(result.success).toEqual(true);
+
+    const { event } = tournamentEngine.getEvent({ drawId });
+    const { extension } = findExtension({ name: DRAW_DELETIONS, element: event });
+    expect(extension).toBeUndefined();
+    const { timeItem } = getTimeItem({ element: event, itemType: DRAW_DELETIONS });
+    expect(timeItem).toBeUndefined();
+  });
+
+  it('saveDrawDeletions=false with no AUDIT subscriber writes nothing', () => {
+    setAuditAuthorityServer(false);
+    setSaveDrawDeletions(false);
+
+    const { drawId, eventId } = seedTournament();
+    const result = tournamentEngine.deleteDrawDefinitions({ drawIds: [drawId], eventId });
+    expect(result.success).toEqual(true);
+
+    const { event } = tournamentEngine.getEvent({ drawId });
+    const { extension } = findExtension({ name: DRAW_DELETIONS, element: event });
+    expect(extension).toBeUndefined();
+    const { timeItem } = getTimeItem({ element: event, itemType: DRAW_DELETIONS });
+    expect(timeItem).toBeUndefined();
+  });
+
+  it('saveDrawDeletions=false still emits the AUDIT notice when subscribed', () => {
+    setAuditAuthorityServer(false);
+    setSaveDrawDeletions(false);
+
+    let noticeCount = 0;
+    setSubscriptions({
+      subscriptions: {
+        [AUDIT]: (notices) => {
+          noticeCount += 1;
+          expect(notices[0].detail[0].payload.drawDefinitions).not.toBeUndefined();
+        },
+      },
+    });
+
+    const { drawId, eventId } = seedTournament();
+    const result = tournamentEngine.deleteDrawDefinitions({ drawIds: [drawId], eventId });
+    expect(result.success).toEqual(true);
+
+    expect(noticeCount).toEqual(1);
+    const { event } = tournamentEngine.getEvent({ drawId });
+    const { extension } = findExtension({ name: DRAW_DELETIONS, element: event });
+    expect(extension).toBeUndefined();
+    const { timeItem } = getTimeItem({ element: event, itemType: DRAW_DELETIONS });
+    expect(timeItem).toBeUndefined();
+  });
+
+  it('saveDrawDeletions=true + AUDIT subscriber writes the timeItem count and emits the notice', () => {
+    setAuditAuthorityServer(false);
+    setSaveDrawDeletions(true);
+
+    let noticeCount = 0;
+    setSubscriptions({
+      subscriptions: {
+        [AUDIT]: () => {
+          noticeCount += 1;
+        },
+      },
+    });
+
+    const { drawId, eventId } = seedTournament();
+    const result = tournamentEngine.deleteDrawDefinitions({ drawIds: [drawId], eventId });
+    expect(result.success).toEqual(true);
+
+    expect(noticeCount).toEqual(1);
+    const { event } = tournamentEngine.getEvent({ drawId });
+    const { extension } = findExtension({ name: DRAW_DELETIONS, element: event });
+    expect(extension).toBeUndefined(); // when AUDIT subscribed, no extension write
+    const { timeItem } = getTimeItem({ element: event, itemType: DRAW_DELETIONS });
+    expect(timeItem?.itemValue).toEqual(1);
+  });
+
+  it('saveDrawDeletions=true + no AUDIT subscriber writes the extension blob', () => {
+    setAuditAuthorityServer(false);
+    setSaveDrawDeletions(true);
+
+    const { drawId, eventId } = seedTournament();
+    const result = tournamentEngine.deleteDrawDefinitions({ drawIds: [drawId], eventId });
+    expect(result.success).toEqual(true);
+
+    const { event } = tournamentEngine.getEvent({ drawId });
+    const { extension } = findExtension({ name: DRAW_DELETIONS, element: event });
+    expect(extension?.value?.length).toEqual(1);
+    expect(extension?.value[0].deletedDrawsDetail[0].positionAssignments).not.toBeUndefined();
+  });
+
+  it('appliedPolicies.audit[DRAW_DELETIONS]=false suppresses the extension (existing semantics preserved)', () => {
+    setAuditAuthorityServer(false);
+    setSaveDrawDeletions(true);
+
+    const { drawId, eventId } = seedTournament();
+    const { tournamentRecord } = tournamentEngine.getTournament();
+    // attach an extension that disables DRAW_DELETIONS audit on the tournament
+    tournamentRecord.extensions = [
+      ...(tournamentRecord.extensions ?? []),
+      { name: APPLIED_POLICIES, value: { audit: { [DRAW_DELETIONS]: false } } },
+    ];
+    tournamentEngine.setState(tournamentRecord);
+
+    const result = tournamentEngine.deleteDrawDefinitions({ drawIds: [drawId], eventId });
+    expect(result.success).toEqual(true);
+
+    const { event } = tournamentEngine.getEvent({ drawId });
+    const { extension } = findExtension({ name: DRAW_DELETIONS, element: event });
+    expect(extension).toBeUndefined();
+  });
+});

--- a/src/tests/testHarness/setSchemaWriteModeLegacy.ts
+++ b/src/tests/testHarness/setSchemaWriteModeLegacy.ts
@@ -1,6 +1,6 @@
 import { beforeEach } from 'vitest';
 
-import { setSchemaWriteMode } from '@Global/state/globalState';
+import { setAuditAuthorityServer, setSaveDrawDeletions, setSchemaWriteMode } from '@Global/state/globalState';
 
 // constants and types
 import { LEGACY } from '@Constants/schemaWriteModeConstants';
@@ -10,10 +10,15 @@ import { LEGACY } from '@Constants/schemaWriteModeConstants';
  *
  * Pins every pre-existing test to LEGACY write mode so historical assertions
  * about `element.extensions[]` and `timeItems[]` keep passing without
- * modification. Tests that exercise the new write modes set the mode
- * explicitly inside the test or via their own `beforeEach`; running after
- * this hook means those overrides are respected.
+ * modification. Also pins the Phase 6 drawDeletions flags so legacy
+ * audit-trail assertions stay valid: production 5.0.0 default is
+ * saveDrawDeletions=false, but tests assume telemetry is written. Tests that
+ * exercise the new gates set the flags explicitly inside the test (or via
+ * their own `beforeEach`); running after this hook means those overrides
+ * are respected.
  */
 beforeEach(() => {
   setSchemaWriteMode(LEGACY);
+  setSaveDrawDeletions(true);
+  setAuditAuthorityServer(false);
 });

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -94,6 +94,7 @@ export type FactoryEngineMethod =
   | 'attachPolicies'
   | 'attachQualifyingStructure'
   | 'attachStructures'
+  | 'auditAuthorityServer'
   | 'automatedPlayoffPositioning'
   | 'automatedPositioning'
   | 'autoSeeding'
@@ -224,6 +225,7 @@ export type FactoryEngineMethod =
   | 'getApplicableAwardProfileLevels'
   | 'getAppliedPolicies'
   | 'getAssignedParticipantIds'
+  | 'getAuditAuthorityServer'
   | 'getAvailableMatchUpsCount'
   | 'getAvailablePlayoffProfiles'
   | 'getAvailableReports'
@@ -317,6 +319,7 @@ export type FactoryEngineMethod =
   | 'getRoundMatchUps'
   | 'getRounds'
   | 'getRoundVisibilityState'
+  | 'getSaveDrawDeletions'
   | 'getScaledEntries'
   | 'getScaleValues'
   | 'getScheduledRoundsDetails'
@@ -506,6 +509,7 @@ export type FactoryEngineMethod =
   | 'reverseScore'
   | 'runValidationPipeline'
   | 'sampleCapacityCurve'
+  | 'saveDrawDeletions'
   | 'scaledTeamAssignment'
   | 'scheduleMatchUps'
   | 'scheduleProfileGrid'
@@ -693,6 +697,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'attachPolicies',
   'attachQualifyingStructure',
   'attachStructures',
+  'auditAuthorityServer',
   'automatedPlayoffPositioning',
   'automatedPositioning',
   'autoSeeding',
@@ -823,6 +828,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getApplicableAwardProfileLevels',
   'getAppliedPolicies',
   'getAssignedParticipantIds',
+  'getAuditAuthorityServer',
   'getAvailableMatchUpsCount',
   'getAvailablePlayoffProfiles',
   'getAvailableReports',
@@ -916,6 +922,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getRoundMatchUps',
   'getRounds',
   'getRoundVisibilityState',
+  'getSaveDrawDeletions',
   'getScaledEntries',
   'getScaleValues',
   'getScheduledRoundsDetails',
@@ -1105,6 +1112,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'reverseScore',
   'runValidationPipeline',
   'sampleCapacityCurve',
+  'saveDrawDeletions',
   'scaledTeamAssignment',
   'scheduleMatchUps',
   'scheduleProfileGrid',


### PR DESCRIPTION
## Summary

CODES Phase 6 — the cross-repo final phase. Factory side of the work.

Two new engine flags gate the `deleteDrawDefinitions` audit-trail writes:

- `engine.saveDrawDeletions(flag)` — opt-in to persist drawDeletions on the tournamentRecord. **Default in 5.0.0: `false`.**
- `engine.auditAuthorityServer(flag)` — declare that an external authority (e.g. `competition-factory-server`) is the canonical audit trail. When `true`, the factory emits the `AUDIT` notice but writes nothing to the record, regardless of `saveDrawDeletions`.

The existing AUDIT topic notice is emitted unchanged so subscribers (the server's `AuditService`) can capture the deleted drawDefinition snapshot. The notice payload already carried `drawDefinitions: [drawDefinition]` (`deleteDrawDefinitions.ts:166-174`), so the snapshot does not need a separate capture path.

## Surface

- `src/global/state/globalState.ts` — `saveDrawDeletions` + `auditAuthorityServer` on `GlobalStateTypes`, setters / getters
- `src/assemblies/engines/parts/engineStart.ts` — `engine.saveDrawDeletions(flag)` + `engine.auditAuthorityServer(flag)` + getters
- `src/mutate/events/deleteDrawDefinitions.ts` — gating; audit dispatch extracted to `dispatchDrawDeletionAudit` to keep cognitive complexity under the per-function lint threshold
- `src/types/factoryEngineMethods.ts` — regenerated
- `src/tests/global/drawDeletionsGating.test.ts` — 7 new tests covering every combination
- `src/tests/testHarness/setSchemaWriteModeLegacy.ts` — pin `saveDrawDeletions: true` + `auditAuthorityServer: false` in the vitest setup so historical assertions about `DRAW_DELETIONS` extensions and `timeItems` keep passing without modification

## Why a major bump

The 5.0.0 default flips from "always write" to "off". Existing in-repo callers that depend on the timeItem count / extension blob need to call `engine.saveDrawDeletions(true)` to preserve behavior. (Internal call sites — TMX, competition-factory-server — are either tracked in the companion PR or implicitly handled.)

## Companion PR

[`competition-factory-server` PR](https://github.com/CourtHive/competition-factory-server/pull/new/feat/codes-phase-6-drawdeletions) wires the AUDIT topic subscription that captures the snapshot into the existing audit log. The server expects `factory >= 5.0.0-alpha.1` (this PR's release).

## Verification

- `pnpm check-types` — green
- `pnpm lint` — green
- `pnpm test --run` — 917 files / 9603 pass / 7 skip / 0 fail (+7 new, no regressions)
- `pnpm build` — green

## Test plan

- [ ] CI green
- [ ] Manual smoke: in a 5.0.0-alpha consumer, call `engine.saveDrawDeletions(false)` and verify the event has no `DRAW_DELETIONS` extension after `deleteDrawDefinitions`
- [ ] Manual smoke: enable `engine.auditAuthorityServer(true)` and verify the AUDIT notice still fires while the event stays clean