### PR TITLE
feat: getTally engine query for mode-agnostic positionAssignment.tally read

### DIFF
--- a/src/assemblies/governors/drawsGovernor/query.ts
+++ b/src/assemblies/governors/drawsGovernor/query.ts
@@ -17,6 +17,7 @@ export { getPositionsPlayedOff } from '@Query/drawDefinition/getPositionsPlayedO
 export { getSwissStandings } from '@Query/drawDefinitions/swiss/getSwissStandings';
 export { isValidForQualifying } from '@Query/drawDefinition/isValidForQualifying';
 export { getPositionAssignments } from '@Query/structure/getPositionAssignments';
+export { getTally } from '@Query/structure/getTally';
 export { getSeedingThresholds } from '@Query/drawDefinition/getSeedBlocks';
 export { getSwissChart } from '@Query/drawDefinitions/swiss/getSwissChart';
 export { validatePlayoffGroups } from '@Validators/validatePlayoffGroups';

--- a/src/query/structure/getTally.ts
+++ b/src/query/structure/getTally.ts
@@ -1,0 +1,26 @@
+import { firstClassOrExtension } from '@Acquire/firstClassOrExtension';
+
+// constants and types
+import { MISSING_POSITION_ASSIGNMENTS, NOT_FOUND } from '@Constants/errorConditionConstants';
+import { TALLY } from '@Constants/extensionConstants';
+
+type GetTallyArgs = {
+  positionAssignment?: any;
+};
+
+/**
+ * Mode-agnostic read of the round-robin tally on a PositionAssignment.
+ *
+ * In NATIVE write mode (5.0.0 default) the tally lives on
+ * `positionAssignment.tally`. In LEGACY mode it lives on
+ * `positionAssignment.extensions[{name: 'tally'}].value`. Callers should
+ * never branch on mode — use this helper.
+ */
+export function getTally({ positionAssignment }: GetTallyArgs) {
+  if (!positionAssignment) return { error: MISSING_POSITION_ASSIGNMENTS };
+
+  const tally = firstClassOrExtension({ element: positionAssignment, attribute: 'tally', name: TALLY });
+  if (tally === undefined) return { error: NOT_FOUND };
+
+  return { tally };
+}

--- a/src/tests/global/getTally.test.ts
+++ b/src/tests/global/getTally.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { setSchemaWriteMode } from '@Global/state/globalState';
+import tournamentEngine from '@Engines/syncEngine';
+
+// constants and types
+import { LEGACY, NATIVE } from '@Constants/schemaWriteModeConstants';
+
+const TALLY_VALUE = { groupOrder: 1, rankOrder: 2, MPctSum: 0.5 };
+
+describe('getTally — mode-agnostic positionAssignment.tally read', () => {
+  it('returns NOT_FOUND when no tally is present', () => {
+    const result: any = tournamentEngine.getTally({ positionAssignment: { drawPosition: 1 } });
+    expect(result.error).toBeDefined();
+    expect(result.tally).toBeUndefined();
+  });
+
+  it('returns MISSING_POSITION_ASSIGNMENTS when positionAssignment is missing', () => {
+    const result: any = tournamentEngine.getTally({});
+    expect(result.error).toBeDefined();
+  });
+
+  it('reads first-class pa.tally when NATIVE-written', () => {
+    setSchemaWriteMode(NATIVE);
+    const result: any = tournamentEngine.getTally({
+      positionAssignment: { drawPosition: 1, tally: TALLY_VALUE },
+    });
+    expect(result.tally).toEqual(TALLY_VALUE);
+  });
+
+  it('reads legacy extension when LEGACY-written', () => {
+    setSchemaWriteMode(LEGACY);
+    const result: any = tournamentEngine.getTally({
+      positionAssignment: {
+        drawPosition: 1,
+        extensions: [{ name: 'tally', value: TALLY_VALUE }],
+      },
+    });
+    expect(result.tally).toEqual(TALLY_VALUE);
+  });
+
+  it('first-class wins when both are present (DUAL-written record)', () => {
+    setSchemaWriteMode(NATIVE);
+    const result: any = tournamentEngine.getTally({
+      positionAssignment: {
+        drawPosition: 1,
+        tally: TALLY_VALUE,
+        extensions: [{ name: 'tally', value: { groupOrder: 999 } }],
+      },
+    });
+    expect(result.tally).toEqual(TALLY_VALUE);
+  });
+});

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -337,6 +337,7 @@ export type FactoryEngineMethod =
   | 'getStructureSeedAssignments'
   | 'getSwissChart'
   | 'getSwissStandings'
+  | 'getTally'
   | 'getTeamLineUp'
   | 'getTiebreakComplement'
   | 'getTieFormat'
@@ -940,6 +941,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getStructureSeedAssignments',
   'getSwissChart',
   'getSwissStandings',
+  'getTally',
   'getTeamLineUp',
   'getTiebreakComplement',
   'getTieFormat',


### PR DESCRIPTION
## Summary

Adds `engine.getTally({ positionAssignment })` — a mode-agnostic read of the round-robin tally on a `PositionAssignment`. Mirrors the existing `getDraftState` / `getFlightProfile` patterns, using `firstClassOrExtension` internally so callers don't have to know about the LEGACY vs NATIVE write split introduced by CODES Phase 1.

Motivated by the TMX 5.0.0 read-migration ([TMX PR link](https://github.com/CourtHive/TMX/pulls)): two sites in TMX were reading `pa.extensions?.find(e => e.name === 'tally')?.value` directly, which silently returns `undefined` against records written under NATIVE schemaWriteMode (the new 5.0.0 default). They now call `tournamentEngine.getTally({ positionAssignment })`.

## What changes

- `src/query/structure/getTally.ts` — new query (~25 lines)
- `src/assemblies/governors/drawsGovernor/query.ts` — wires the export
- `src/types/factoryEngineMethods.ts` — regenerated (601 → 602 methods)
- `src/tests/global/getTally.test.ts` — 5 new tests covering NATIVE-only, LEGACY-only, both-present (first-class wins), missing tally, and missing positionAssignment

## Non-breaking

Purely additive — no existing read or write paths change. Will be picked up by the open release-please PR for 5.0.0.

## Verification

- `pnpm check-types` — green
- `pnpm lint` — green
- `pnpm test --run` — 918 files / 9608 pass / 7 skip / 0 fail (+5 new)
- `pnpm build` — green

## Test plan

- [ ] CI green
- [ ] release-please PR #4383 picks up this commit and includes \`getTally\` in the 5.0.0 changelog