### PR TITLE
feat: matchUp.schedule.calledAt + setMatchUpCalledAt mutation

### DIFF
--- a/src/assemblies/governors/scheduleGovernor/mutate.ts
+++ b/src/assemblies/governors/scheduleGovernor/mutate.ts
@@ -25,6 +25,7 @@ export { addMatchUpScheduledTime } from '@Mutate/matchUps/schedule/scheduledTime
 export { setMatchUpDailyLimits } from '@Mutate/tournaments/setMatchUpDailyLimits';
 export { assignMatchUpCourt } from '@Mutate/matchUps/schedule/assignMatchUpCourt';
 export { assignMatchUpVenue } from '@Mutate/matchUps/schedule/assignMatchUpVenue';
+export { setMatchUpCalledAt } from '@Mutate/matchUps/schedule/setMatchUpCalledAt';
 export { generateBookings } from '@Generators/scheduling/utils/generateBookings';
 export { validateSchedulingProfile } from '@Validators/validateSchedulingProfile';
 export { setSchedulingProfile } from '@Mutate/tournaments/schedulingProfile';

--- a/src/mutate/matchUps/schedule/setMatchUpCalledAt.ts
+++ b/src/mutate/matchUps/schedule/setMatchUpCalledAt.ts
@@ -1,0 +1,74 @@
+import { modifyMatchUpNotice } from '@Mutate/notifications/drawNotifications';
+import { decorateResult } from '@Functions/global/decorateResult';
+import { findDrawMatchUp } from '@Acquire/findDrawMatchUp';
+
+// constants and types
+import {
+  INVALID_VALUES,
+  MATCHUP_NOT_FOUND,
+  MISSING_DRAW_DEFINITION,
+  MISSING_MATCHUP_ID,
+} from '@Constants/errorConditionConstants';
+import { DrawDefinition, Event, Tournament } from '@Types/tournamentTypes';
+import { SUCCESS } from '@Constants/resultConstants';
+
+type SetMatchUpCalledAtArgs = {
+  tournamentRecord?: Tournament;
+  drawDefinition: DrawDefinition;
+  disableNotice?: boolean;
+  // ISO timestamp string when the matchUp is placed on the TMX active strip;
+  // null or undefined clears the previous value (explicit removal).
+  calledAt?: string | null;
+  matchUpId: string;
+  event?: Event;
+};
+
+/**
+ * Set or clear `matchUp.schedule.calledAt` — the ISO-string timestamp captured
+ * at the moment a tournament director deliberately drag-drops a matchUp onto
+ * the TMX "active strip" / NOW row, signalling that the matchUp is imminent
+ * ("calling the match to court").
+ *
+ * Semantics:
+ *  - Pass an ISO string to set the timestamp.
+ *  - Pass `null` or `undefined` to clear (explicit removal).
+ *  - Subsequent set calls overwrite the prior value.
+ *  - Persists past START_TIME as a historical record — NOT auto-cleared on
+ *    lifecycle transition. Clear only via explicit removal.
+ *  - Distinct from `scheduledTime` (plan), `courtId` (place), and the
+ *    `START_TIME` timeItem (actually started). May coexist with all of them.
+ *  - This is a CODES 5.0.0 NEW first-class attribute — no legacy timeItem
+ *    mirror, no LEGACY/DUAL/NATIVE branching. The attribute is always
+ *    written to `matchUp.schedule.calledAt`.
+ */
+export function setMatchUpCalledAt(params: SetMatchUpCalledAtArgs) {
+  const stack = 'setMatchUpCalledAt';
+  const { tournamentRecord, drawDefinition, disableNotice, calledAt, matchUpId, event } = params;
+
+  if (!drawDefinition) return decorateResult({ result: { error: MISSING_DRAW_DEFINITION }, stack });
+  if (!matchUpId) return decorateResult({ result: { error: MISSING_MATCHUP_ID }, stack });
+  if (calledAt !== undefined && calledAt !== null && typeof calledAt !== 'string') {
+    return decorateResult({ result: { error: INVALID_VALUES }, stack, info: 'calledAt must be an ISO string' });
+  }
+
+  const { matchUp } = findDrawMatchUp({ drawDefinition, event, matchUpId });
+  if (!matchUp) return decorateResult({ result: { error: MATCHUP_NOT_FOUND }, stack });
+
+  if (calledAt === undefined || calledAt === null) {
+    if (matchUp.schedule) delete matchUp.schedule.calledAt;
+  } else {
+    if (!matchUp.schedule) matchUp.schedule = {};
+    matchUp.schedule.calledAt = calledAt;
+  }
+
+  if (!disableNotice) {
+    modifyMatchUpNotice({
+      drawDefinition,
+      tournamentId: tournamentRecord?.tournamentId,
+      context: stack,
+      matchUp,
+    });
+  }
+
+  return { ...SUCCESS };
+}

--- a/src/tests/global/setMatchUpCalledAt.test.ts
+++ b/src/tests/global/setMatchUpCalledAt.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import { setSchemaWriteMode } from '@Global/state/globalState';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+
+// constants and types
+import { NATIVE } from '@Constants/schemaWriteModeConstants';
+
+const ISO_A = '2026-05-27T13:58:42.000Z';
+const ISO_B = '2026-05-27T14:05:00.000Z';
+
+function seedTournament() {
+  const result = mocksEngine.generateTournamentRecord({
+    inContext: true,
+    setState: true,
+    drawProfiles: [{ participantsCount: 8, drawSize: 8 }],
+  });
+  const drawId = result.drawIds[0];
+  const eventId = result.eventIds[0];
+  const matchUpId = result.tournamentRecord.events[0].drawDefinitions[0].structures[0].matchUps[0].matchUpId;
+  return { drawId, eventId, matchUpId };
+}
+
+describe('setMatchUpCalledAt — matchUp.schedule.calledAt mutation', () => {
+  it('sets calledAt to an ISO string when none was present', () => {
+    const { drawId, matchUpId } = seedTournament();
+
+    const result: any = tournamentEngine.setMatchUpCalledAt({ drawId, matchUpId, calledAt: ISO_A });
+    expect(result.success).toEqual(true);
+
+    const { matchUp } = tournamentEngine.findMatchUp({ matchUpId });
+    expect(matchUp?.schedule?.calledAt).toEqual(ISO_A);
+  });
+
+  it('overwrites a prior calledAt on a second call', () => {
+    const { drawId, matchUpId } = seedTournament();
+
+    tournamentEngine.setMatchUpCalledAt({ drawId, matchUpId, calledAt: ISO_A });
+    tournamentEngine.setMatchUpCalledAt({ drawId, matchUpId, calledAt: ISO_B });
+
+    const { matchUp } = tournamentEngine.findMatchUp({ matchUpId });
+    expect(matchUp?.schedule?.calledAt).toEqual(ISO_B);
+  });
+
+  it('clears calledAt when called with null', () => {
+    const { drawId, matchUpId } = seedTournament();
+
+    tournamentEngine.setMatchUpCalledAt({ drawId, matchUpId, calledAt: ISO_A });
+    const clearResult: any = tournamentEngine.setMatchUpCalledAt({ drawId, matchUpId, calledAt: null });
+    expect(clearResult.success).toEqual(true);
+
+    const { matchUp } = tournamentEngine.findMatchUp({ matchUpId });
+    expect(matchUp?.schedule?.calledAt).toBeUndefined();
+  });
+
+  it('clears calledAt when called with undefined', () => {
+    const { drawId, matchUpId } = seedTournament();
+
+    tournamentEngine.setMatchUpCalledAt({ drawId, matchUpId, calledAt: ISO_A });
+    tournamentEngine.setMatchUpCalledAt({ drawId, matchUpId, calledAt: undefined });
+
+    const { matchUp } = tournamentEngine.findMatchUp({ matchUpId });
+    expect(matchUp?.schedule?.calledAt).toBeUndefined();
+  });
+
+  it('preserves coexisting schedule attributes (scheduledTime) when set', () => {
+    // Pin NATIVE so addMatchUpScheduledTime writes the first-class attribute
+    // (the vitest setupFile defaults to LEGACY, which would route it to a
+    // timeItem instead). The point of this test is to verify schedule-object
+    // isolation, which only makes sense when both writes are first-class.
+    setSchemaWriteMode(NATIVE);
+    const { drawId, matchUpId } = seedTournament();
+
+    tournamentEngine.addMatchUpScheduledTime({ drawId, matchUpId, scheduledTime: '14:00' });
+    tournamentEngine.setMatchUpCalledAt({ drawId, matchUpId, calledAt: ISO_A });
+
+    const { matchUp } = tournamentEngine.findMatchUp({ matchUpId });
+    expect(matchUp?.schedule?.calledAt).toEqual(ISO_A);
+    expect(matchUp?.schedule?.scheduledTime).toEqual('14:00');
+  });
+
+  it('returns MATCHUP_NOT_FOUND when the matchUpId does not exist', () => {
+    const { drawId } = seedTournament();
+    const result: any = tournamentEngine.setMatchUpCalledAt({
+      drawId,
+      matchUpId: 'no-such-matchUp',
+      calledAt: ISO_A,
+    });
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects non-string calledAt values', () => {
+    const { drawId, matchUpId } = seedTournament();
+    const result: any = tournamentEngine.setMatchUpCalledAt({ drawId, matchUpId, calledAt: 12345 as any });
+    expect(result.error).toBeDefined();
+  });
+});

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -527,6 +527,7 @@ export type FactoryEngineMethod =
   | 'setEventDisplay'
   | 'setEventEndDate'
   | 'setEventStartDate'
+  | 'setMatchUpCalledAt'
   | 'setMatchUpDailyLimits'
   | 'setMatchUpFormat'
   | 'setMatchUpHomeParticipantId'
@@ -1131,6 +1132,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'setEventDisplay',
   'setEventEndDate',
   'setEventStartDate',
+  'setMatchUpCalledAt',
   'setMatchUpDailyLimits',
   'setMatchUpFormat',
   'setMatchUpHomeParticipantId',

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -356,6 +356,11 @@ export type EventTypeUnion = 'SINGLES' | 'DOUBLES' | 'TEAM' | 'HYBRID';
  */
 export interface MatchUpSchedule {
   allocatedCourts?: any[];
+  // CODES 5.0.0 first-class: ISO timestamp captured when the matchUp is
+  // deliberately placed on the TMX active strip ("calling the match to court").
+  // Distinct from scheduledTime (plan) and START_TIME timeItem (actual start).
+  // Cleared only by explicit removal; persists past START_TIME as history.
+  calledAt?: string;
   courtAnnotation?: string;
   courtId?: string;
   courtOrder?: number;


### PR DESCRIPTION
## Summary

New CODES first-class attribute on `matchUp.schedule.calledAt` — an ISO timestamp captured the moment a tournament director **deliberately** drag-drops a matchUp onto a live "now playing" / "active strip" UI in a client app. The signal means *"we are telling the world that this matchUp is imminent on this court."*

Distinct from existing fields:
- `matchUp.schedule.scheduledTime` — the **plan**
- `matchUp.schedule.courtId` — the **place**
- `matchUp.timeItems[{itemType:'START_TIME'}]` — the **actual start**

## Locked design (with user)

| Decision | Choice |
|---|---|
| Location | Flat first-class peer on `matchUp.schedule.*` (alphabetical, alongside `courtId`, `scheduledTime`, etc.) |
| Name | `calledAt` (tennis-canonical "calling the match to court") |
| Clear semantics | Cleared only on explicit removal. `setMatchUpCalledAt({ ..., calledAt: null })` clears; subsequent drops overwrite. Persists past `START_TIME` as historical record |
| Legacy mirror | None — brand new in 5.0.0; no v4 records ever had this; writes are always first-class regardless of `schemaWriteMode` |

## What ships

- `MatchUpSchedule.calledAt?: string` on the type (alphabetical placement)
- `engine.setMatchUpCalledAt({ drawId, matchUpId, calledAt })` — null/undefined clears, ISO string sets
- Wired through `scheduleGovernor.mutate` (auto-discovered)
- `src/types/factoryEngineMethods.ts` regenerated (602 → 603 methods)
- 7 new tests covering: set, overwrite, clear (null), clear (undefined), coexistence with `scheduledTime` (NATIVE-pinned for that assertion), missing matchUp, invalid input

## Companion PRs

- TMX: [`feat/now-strip-calledAt`](https://github.com/CourtHive/TMX/pulls) wires the active-strip drop handler + unschedule paths to call this mutation
- factory docs: [`docs/migration-5.0.0`](https://github.com/CourtHive/competition-factory/pulls) — the 5.0.0 consumer migration guide includes a section on the `calledAt` pattern

## Verification

- `pnpm check-types` — green
- `pnpm lint` — green
- `pnpm test --run` — 919 files / 9615 pass / 7 skip / 0 fail (+7 new)
- `pnpm build` — green

## Test plan

- [ ] CI green
- [ ] release-please PR picks this commit up under Features in the 5.0.0 changelog