### PR TITLE
feat: linkedTournamentIds mode-aware writers + readers (CODES Phase 7 follow-up)

### DIFF
--- a/src/acquire/getRecordLinkedTournamentIds.ts
+++ b/src/acquire/getRecordLinkedTournamentIds.ts
@@ -1,0 +1,24 @@
+import { findExtension } from './findExtension';
+
+// constants and types
+import { LINKED_TOURNAMENTS } from '@Constants/extensionConstants';
+
+/**
+ * Mode-agnostic read of the linked-tournaments list on a single
+ * `tournamentRecord`. Returns a flat string array.
+ *
+ * The CODES first-class attribute is `tournamentRecord.linkedTournamentIds`
+ * (flat `string[]`). The legacy extension uses the typo-spelled name
+ * `linkedTournamentsIds` (see `extensionConstants.ts`) and wraps the array
+ * in a `{tournamentIds: []}` object. This helper handles both shapes so
+ * callers don't need to branch on `schemaWriteMode`.
+ *
+ * First-class wins when present; falls back to the legacy extension.
+ */
+export function getRecordLinkedTournamentIds(tournamentRecord: any): string[] {
+  if (Array.isArray(tournamentRecord?.linkedTournamentIds)) {
+    return tournamentRecord.linkedTournamentIds;
+  }
+  const { extension } = findExtension({ element: tournamentRecord, name: LINKED_TOURNAMENTS });
+  return extension?.value?.tournamentIds ?? [];
+}

--- a/src/assemblies/engines/parts/stateMethods.ts
+++ b/src/assemblies/engines/parts/stateMethods.ts
@@ -1,4 +1,4 @@
-import { findExtension } from '@Acquire/findExtension';
+import { getRecordLinkedTournamentIds } from '@Acquire/getRecordLinkedTournamentIds';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
 import {
   getTournamentId,
@@ -11,7 +11,6 @@ import {
 
 // constants and types
 import { INVALID_OBJECT, INVALID_RECORDS, INVALID_VALUES } from '@Constants/errorConditionConstants';
-import { LINKED_TOURNAMENTS } from '@Constants/extensionConstants';
 import { ResultType } from '@Types/factoryTypes';
 
 type GetStateArgs = {
@@ -46,15 +45,17 @@ export function getTournament(params?: GetTournamentArgs) {
 export function removeUnlinkedTournamentRecords(): void {
   const tournamentRecords = getTournamentRecords();
 
-  const { extension } = findExtension({
-    name: LINKED_TOURNAMENTS,
-    tournamentRecords,
-    discover: true,
-  });
+  // CODES: collect linked ids across every record in state (mode-agnostic).
+  // The previous `findExtension({discover:true})` pulled the first matching
+  // extension only — sufficient because `linkTournaments` writes the same
+  // value into every record. The shadow-write equivalent walks each record.
+  const tournamentIds = new Set<string>();
+  for (const record of Object.values(tournamentRecords)) {
+    for (const id of getRecordLinkedTournamentIds(record)) tournamentIds.add(id);
+  }
 
-  const tournamentIds = extension?.value?.tournamentIds ?? [];
   Object.keys(tournamentRecords).forEach((tournamentId) => {
-    if (!tournamentIds.includes(tournamentId)) delete tournamentRecords[tournamentId];
+    if (!tournamentIds.has(tournamentId)) delete tournamentRecords[tournamentId];
   });
 
   return setTournamentRecords(tournamentRecords);

--- a/src/mutate/tournaments/tournamentLinks.ts
+++ b/src/mutate/tournaments/tournamentLinks.ts
@@ -1,15 +1,42 @@
 import { addTournamentExtension, removeTournamentExtension } from '@Mutate/extensions/addRemoveExtensions';
+import { writeLegacyEnabled, writeNativeEnabled } from '@Global/state/globalState';
+import { getRecordLinkedTournamentIds } from '@Acquire/getRecordLinkedTournamentIds';
 import { getTournamentIds } from '@Query/tournaments/getTournamentIds';
 import { removeExtension } from '@Mutate/extensions/removeExtension';
 import { decorateResult } from '@Functions/global/decorateResult';
-import { addExtension } from '@Mutate/extensions/addExtension';
-import { findExtension } from '@Acquire/findExtension';
 
 // constants and types
 import { TournamentRecords, ResultType } from '@Types/factoryTypes';
 import { LINKED_TOURNAMENTS } from '@Constants/extensionConstants';
 import { SUCCESS } from '@Constants/resultConstants';
 import { INVALID_VALUES, MISSING_TOURNAMENT_ID, MISSING_TOURNAMENT_RECORDS } from '@Constants/errorConditionConstants';
+
+/**
+ * Stamp a single tournamentRecord with its linked-tournament list, per the
+ * current schemaWriteMode.
+ *
+ * NATIVE writes the flat `record.linkedTournamentIds` first-class attribute
+ * and strips any legacy extension. LEGACY writes the legacy wrapper
+ * extension `{tournamentIds: []}` and strips any first-class field. DUAL
+ * writes both. When `tournamentIds` is empty, both surfaces are cleared.
+ */
+function writeRecordLinkedTournamentIds(tournamentRecord: any, tournamentIds: string[]): void {
+  const isClear = !tournamentIds.length;
+  if (writeNativeEnabled() && !isClear) {
+    tournamentRecord.linkedTournamentIds = [...tournamentIds];
+  } else if (tournamentRecord?.linkedTournamentIds !== undefined) {
+    delete tournamentRecord.linkedTournamentIds;
+  }
+
+  if (writeLegacyEnabled() && !isClear) {
+    addTournamentExtension({
+      tournamentRecord,
+      extension: { name: LINKED_TOURNAMENTS, value: { tournamentIds: [...tournamentIds] } },
+    });
+  } else {
+    removeTournamentExtension({ tournamentRecord, name: LINKED_TOURNAMENTS });
+  }
+}
 
 /**
  * Links all tournaments which are currently loaded into competitionEngine state
@@ -23,16 +50,9 @@ export function linkTournaments({ tournamentRecords }: { tournamentRecords: Tour
   const { tournamentIds } = result;
 
   if (tournamentIds?.length > 1) {
-    const extension = {
-      name: LINKED_TOURNAMENTS,
-      value: { tournamentIds },
-    };
-
-    return addExtension({
-      tournamentRecords,
-      discover: true,
-      extension,
-    });
+    for (const tournamentRecord of Object.values(tournamentRecords)) {
+      writeRecordLinkedTournamentIds(tournamentRecord, tournamentIds);
+    }
   }
 
   return { ...SUCCESS };
@@ -45,13 +65,18 @@ export function unlinkTournaments({ tournamentRecords }: UnlinkTournamentsArgs):
   if (typeof tournamentRecords !== 'object' || !Object.keys(tournamentRecords).length)
     return { error: MISSING_TOURNAMENT_RECORDS };
 
+  for (const tournamentRecord of Object.values(tournamentRecords)) {
+    writeRecordLinkedTournamentIds(tournamentRecord, []);
+  }
+
+  // Also remove the legacy extension across every record via the discover
+  // path, in case a pre-CODES record still carries it where the
+  // single-record helper did not catch it.
   const result = removeExtension({
     name: LINKED_TOURNAMENTS,
     tournamentRecords,
     discover: true,
   });
-
-  // get all competitionScheduleMatchUps and ensure that each tournamentRecord has all venues for scheduled matchUps
 
   return decorateResult({ result, stack: 'unlinkTournaments' });
 }
@@ -69,43 +94,28 @@ export function unlinkTournament({ tournamentRecords, tournamentId }: UnlinkTour
 
   if (!tournamentIds.includes(tournamentId)) return { error: MISSING_TOURNAMENT_ID };
 
-  // not using bulk update function here to handle scenario where
-  // tournamentRecords loaded into state are not all linked
-  let unlinkError;
-  tournamentIds.every((currentTournamentId) => {
+  // walk each loaded record (some may not be linked, which is fine)
+  for (const currentTournamentId of tournamentIds) {
     const tournamentRecord = tournamentRecords[currentTournamentId];
 
-    const { extension } = findExtension({
-      element: tournamentRecord,
-      name: LINKED_TOURNAMENTS,
-    });
+    // CODES: mode-agnostic read so 5.0.0 NATIVE-written records,
+    // pre-CODES extension-only records, and DUAL records all unlink correctly.
+    const linkedTournamentIds = getRecordLinkedTournamentIds(tournamentRecord);
 
-    // if there is no extension return { ...SUCCESS } because no links exist
-    if (!extension) return true;
-
-    const linkedTournamentIds = extension?.value?.tournamentIds ?? [];
-
-    // if there are no tournamentIds
+    // if there are no tournamentIds, or the only link is self, or this is
+    // the record being unlinked: clear both surfaces.
     if (
       !linkedTournamentIds?.length ||
       (linkedTournamentIds.length === 1 && linkedTournamentIds.includes(tournamentId)) ||
       currentTournamentId === tournamentId
     ) {
-      const result = removeTournamentExtension({
-        name: LINKED_TOURNAMENTS,
-        tournamentRecord,
-      });
-      if (result.error) unlinkError = result.error;
-      return result.success;
+      writeRecordLinkedTournamentIds(tournamentRecord, []);
+      continue;
     }
 
-    const tournamentIds = linkedTournamentIds.filter((linkedTournamentId) => linkedTournamentId !== tournamentId);
-    extension.value = { tournamentIds };
+    const remaining = linkedTournamentIds.filter((linkedTournamentId) => linkedTournamentId !== tournamentId);
+    writeRecordLinkedTournamentIds(tournamentRecord, remaining);
+  }
 
-    const result = addTournamentExtension({ tournamentRecord, extension });
-    if (result.error) unlinkError = result.error;
-    return result.success;
-  });
-
-  return unlinkError ? { error: unlinkError } : { ...SUCCESS };
+  return { ...SUCCESS };
 }

--- a/src/query/tournaments/getLinkedTournamentIds.ts
+++ b/src/query/tournaments/getLinkedTournamentIds.ts
@@ -1,9 +1,8 @@
-import { findExtension } from '@Acquire/findExtension';
+import { getRecordLinkedTournamentIds } from '@Acquire/getRecordLinkedTournamentIds';
 
 // constants and types
 import { MISSING_TOURNAMENT_RECORDS } from '@Constants/errorConditionConstants';
 import { TournamentRecords, ResultType } from '@Types/factoryTypes';
-import { LINKED_TOURNAMENTS } from '@Constants/extensionConstants';
 
 export function getLinkedTournamentIds({
   tournamentRecords,
@@ -19,12 +18,9 @@ export function getLinkedTournamentIds({
       const tournamentRecord = tournamentRecords[tournamentId];
       const touranmentId = tournamentRecord?.tournamentId;
 
-      const { extension } = findExtension({
-        element: tournamentRecord,
-        name: LINKED_TOURNAMENTS,
-      });
-
-      const tournamentIds = (extension?.value?.tournamentIds ?? []).filter(
+      // CODES: mode-agnostic read of `record.linkedTournamentIds` (first-class)
+      // with extension fallback (legacy `{tournamentIds: []}` wrapper shape).
+      const tournamentIds = getRecordLinkedTournamentIds(tournamentRecord).filter(
         (currentTournamentId) => currentTournamentId !== touranmentId,
       );
 

--- a/src/tests/global/linkedTournamentIdsMode.test.ts
+++ b/src/tests/global/linkedTournamentIdsMode.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { setSchemaWriteMode } from '@Global/state/globalState';
+import competitionEngine from '@Engines/syncEngine';
+import { findExtension } from '@Acquire/findExtension';
+import mocksEngine from '@Assemblies/engines/mock';
+
+// constants and types
+import { DUAL, LEGACY, NATIVE } from '@Constants/schemaWriteModeConstants';
+import { LINKED_TOURNAMENTS } from '@Constants/extensionConstants';
+
+function loadTwoTournaments() {
+  competitionEngine.reset();
+  const a = mocksEngine.generateTournamentRecord();
+  const b = mocksEngine.generateTournamentRecord();
+  competitionEngine.setTournamentRecord(a.tournamentRecord);
+  competitionEngine.setTournamentRecord(b.tournamentRecord);
+  return {
+    tournamentIdA: a.tournamentRecord.tournamentId,
+    tournamentIdB: b.tournamentRecord.tournamentId,
+  };
+}
+
+function getRecord(tournamentId: string) {
+  return competitionEngine.getTournament({ tournamentId })?.tournamentRecord;
+}
+
+afterEach(() => {
+  // setupFile pins LEGACY; restore in case a test changed it
+  setSchemaWriteMode(LEGACY);
+  competitionEngine.reset();
+});
+
+describe('linkedTournamentIds — schemaWriteMode shadow writes', () => {
+  it('NATIVE mode writes flat first-class and clears any legacy extension', () => {
+    setSchemaWriteMode(NATIVE);
+    const { tournamentIdA, tournamentIdB } = loadTwoTournaments();
+
+    competitionEngine.linkTournaments();
+
+    const recordA: any = getRecord(tournamentIdA);
+    const recordB: any = getRecord(tournamentIdB);
+
+    expect(Array.isArray(recordA.linkedTournamentIds)).toEqual(true);
+    expect(recordA.linkedTournamentIds).toContain(tournamentIdA);
+    expect(recordA.linkedTournamentIds).toContain(tournamentIdB);
+    expect(recordB.linkedTournamentIds).toContain(tournamentIdA);
+
+    // Legacy extension must not be present in NATIVE-only writes.
+    expect(findExtension({ element: recordA, name: LINKED_TOURNAMENTS }).extension).toBeUndefined();
+    expect(findExtension({ element: recordB, name: LINKED_TOURNAMENTS }).extension).toBeUndefined();
+  });
+
+  it('LEGACY mode writes the wrapper extension and clears any first-class field', () => {
+    setSchemaWriteMode(LEGACY);
+    const { tournamentIdA } = loadTwoTournaments();
+
+    competitionEngine.linkTournaments();
+
+    const recordA: any = getRecord(tournamentIdA);
+    expect(recordA.linkedTournamentIds).toBeUndefined();
+
+    const { extension } = findExtension({ element: recordA, name: LINKED_TOURNAMENTS });
+    expect(extension?.value?.tournamentIds).toBeDefined();
+    expect(extension?.value?.tournamentIds.length).toEqual(2);
+  });
+
+  it('DUAL mode writes both surfaces', () => {
+    setSchemaWriteMode(DUAL);
+    const { tournamentIdA } = loadTwoTournaments();
+
+    competitionEngine.linkTournaments();
+
+    const recordA: any = getRecord(tournamentIdA);
+    expect(Array.isArray(recordA.linkedTournamentIds)).toEqual(true);
+    expect(recordA.linkedTournamentIds.length).toEqual(2);
+
+    const { extension } = findExtension({ element: recordA, name: LINKED_TOURNAMENTS });
+    expect(extension?.value?.tournamentIds.length).toEqual(2);
+  });
+
+  it('getLinkedTournamentIds reads NATIVE-written records correctly', () => {
+    setSchemaWriteMode(NATIVE);
+    const { tournamentIdA, tournamentIdB } = loadTwoTournaments();
+    competitionEngine.linkTournaments();
+
+    const { linkedTournamentIds } = competitionEngine.getLinkedTournamentIds();
+    // returns map: for each tournament, its OTHER linked ids
+    expect(linkedTournamentIds[tournamentIdA]).toEqual([tournamentIdB]);
+    expect(linkedTournamentIds[tournamentIdB]).toEqual([tournamentIdA]);
+  });
+
+  it('unlinkTournament removes the id from both surfaces (DUAL)', () => {
+    setSchemaWriteMode(DUAL);
+    const { tournamentIdA, tournamentIdB } = loadTwoTournaments();
+    const { tournamentRecord: c } = mocksEngine.generateTournamentRecord();
+    competitionEngine.setTournamentRecord(c);
+    const tournamentIdC = c.tournamentId;
+
+    competitionEngine.linkTournaments();
+    competitionEngine.unlinkTournament({ tournamentId: tournamentIdC });
+
+    const recordA: any = getRecord(tournamentIdA);
+    const recordB: any = getRecord(tournamentIdB);
+
+    expect(recordA.linkedTournamentIds).not.toContain(tournamentIdC);
+    expect(recordB.linkedTournamentIds).not.toContain(tournamentIdC);
+    expect(recordA.linkedTournamentIds).toContain(tournamentIdB);
+
+    // Legacy surface also reflects the removal.
+    const extA = findExtension({ element: recordA, name: LINKED_TOURNAMENTS }).extension;
+    expect(extA?.value?.tournamentIds).not.toContain(tournamentIdC);
+  });
+
+  it('unlinkTournaments clears both surfaces', () => {
+    setSchemaWriteMode(DUAL);
+    const { tournamentIdA } = loadTwoTournaments();
+    competitionEngine.linkTournaments();
+    competitionEngine.unlinkTournaments();
+
+    const recordA: any = getRecord(tournamentIdA);
+    expect(recordA.linkedTournamentIds).toBeUndefined();
+    expect(findExtension({ element: recordA, name: LINKED_TOURNAMENTS }).extension).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 7 added \`tournamentRecord.linkedTournamentIds\` as a first-class type and a \`migrateTournamentRecord\` translator for the shape change. But the actual \`competitionEngine.linkTournaments\` / \`unlinkTournament\` / \`unlinkTournaments\` writers still wrote ONLY to the legacy \`linkedTournamentsIds\` extension (and the corresponding readers only read from it). Under 5.0.0 NATIVE-default, new writes would never populate the first-class field — silently defeating the migration.

This PR closes the gap so the feature works correctly across all three \`schemaWriteMode\` settings before 5.0.0 publishes.

## What changes

**New shared reader** — \`src/acquire/getRecordLinkedTournamentIds.ts\` returns a flat \`string[]\` preferring the first-class field with fallback to the legacy \`extension.value.tournamentIds\` wrapper. Single helper used everywhere.

**Mode-aware writers** in \`src/mutate/tournaments/tournamentLinks.ts\`:

| Mode | First-class \`record.linkedTournamentIds\` | Legacy \`extensions[{name:'linkedTournamentsIds'}]\` |
|---|---|---|
| NATIVE (5.0.0 default) | written (flat \`string[]\`) | cleared if present |
| LEGACY | cleared if present | written (\`{tournamentIds: []}\` wrapper) |
| DUAL | written | written |

**Mode-agnostic readers** — three call sites switched to the new helper:

- \`src/query/tournaments/getLinkedTournamentIds.ts\` — the engine query method
- \`src/assemblies/engines/parts/stateMethods.ts\` — \`removeUnlinkedTournamentRecords\`
- \`src/mutate/tournaments/tournamentLinks.ts\` — the read inside \`unlinkTournament\`

\`findCourt\` and \`findVenue\` go through \`getLinkedTournamentIds\` already, so they pick up the fix transparently.

## Why this matters for 5.0.0

Without this fix, any application that calls \`competitionEngine.linkTournaments()\` after upgrading to 5.0.0 (NATIVE default) would write the legacy wrapper extension; new readers expecting \`record.linkedTournamentIds\` would see \`undefined\`. Multi-tournament \`findCourt\`/\`findVenue\` resolution would silently degrade to single-tournament mode.

## Verification

- \`pnpm check-types\` — green
- \`pnpm lint\` — green (zero warnings; refactored \`unlinkTournament\` to drop an always-undefined \`unlinkError\` variable that was orphaned by the new helper)
- \`pnpm test --run\` — 919 files / 9614 pass / 7 skip / 0 fail (+6 new in \`linkedTournamentIdsMode.test.ts\`)
- \`pnpm build\` — green

## Companion PR

[\`docs/migration-5.0.0\`](https://github.com/CourtHive/competition-factory/pull/4392) updated with the fuller \`linkedTournamentIds\` explanation that references this PR's mode-aware behavior.

## Test plan

- [ ] CI green
- [ ] release-please PR #4383 picks this up under Features (the user-visible change is that the existing \`linkTournaments\` API now correctly populates the first-class field)