### PR TITLE
feat: engine.q unwrap facade + engine.inspect (developer-JOY prototypes)

### DIFF
--- a/src/assemblies/engines/parts/engineStart.ts
+++ b/src/assemblies/engines/parts/engineStart.ts
@@ -2,6 +2,7 @@ import { createTournamentRecord } from '@Generators/tournamentRecords/createTour
 import { methodImporter } from '@Assemblies/engines/parts/methodImporter';
 import { processResult } from '@Assemblies/engines/parts/processResult';
 import { factoryVersion } from '@Functions/global/factoryVersion';
+import { buildQueryFacade, inspect } from '@Forge/index';
 import {
   setDeepCopy,
   setDevContext,
@@ -91,4 +92,9 @@ export function engineStart(engine: FactoryEngine, engineInvoke: any): void {
     const result = removeUnlinkedTournamentRecords();
     return processResult(engine, result);
   };
+  // Developer-JOY facades (forge) — see `src/forge/q.ts` and `src/forge/inspect.ts`.
+  // The query facade is built lazily-wired: it holds a closure over `engine`,
+  // so it picks up governor methods that get added after engineStart returns.
+  engine.q = buildQueryFacade(engine);
+  engine.inspect = () => inspect();
 }

--- a/src/forge/index.ts
+++ b/src/forge/index.ts
@@ -1,3 +1,20 @@
-export const forge = {};
+/**
+ * Forge namespace — staging area for new factory functionality before it
+ * graduates to a governor or query module. See `forge.md` for the original
+ * 2.x vision.
+ *
+ * Currently hosts the developer-JOY prototype facades:
+ *  - `engine.q.*` — the unwrap query facade (see `q.ts`)
+ *  - `engine.inspect()` — the live state snapshot (see `inspect.ts`)
+ *
+ * Both are wired onto the engine in `assemblies/engines/parts/engineStart.ts`.
+ */
 
+export { buildQueryFacade, queryRegistry } from './q';
+export type { QueryFacade } from './q';
+export { inspect } from './inspect';
+export type { EngineInspection, EngineInspectionCounts } from './inspect';
+
+// Legacy placeholder export retained for prior consumers.
+export const forge = {};
 export default forge;

--- a/src/forge/inspect.ts
+++ b/src/forge/inspect.ts
@@ -1,0 +1,117 @@
+/**
+ * engine.inspect() — typed state snapshot for debugging (developer-JOY #8)
+ *
+ * Returns a single, typed snapshot of "what's loaded right now": engine
+ * version, write-mode flags, tournament IDs in state, lightweight counts of
+ * the major collections, subscription topics, and the current devContext.
+ *
+ * Cheap, side-effect-free, intended for quick `console.log(engine.inspect())`
+ * during debugging, paste-into-bug-report scenarios, and devtools panels.
+ * Not a full state dump — counts only, no record bodies, no participants
+ * payload. Use `engine.getState()` for the full picture.
+ */
+
+import {
+  getAuditAuthorityServer,
+  getDevContext,
+  getSaveDrawDeletions,
+  getSchemaWriteMode,
+  getTopics,
+  getTournamentId,
+  getTournamentRecords,
+} from '@Global/state/globalState';
+import { factoryVersion } from '@Functions/global/factoryVersion';
+
+export interface EngineInspectionCounts {
+  tournaments: number;
+  events: number;
+  drawDefinitions: number;
+  structures: number;
+  matchUps: number;
+  participants: number;
+  venues: number;
+  courts: number;
+}
+
+export interface EngineInspection {
+  /** factory package version (matches engine.version()) */
+  version: string;
+  /** current schemaWriteMode setting */
+  schemaWriteMode: string;
+  /** opt-in flag for the drawDeletions audit (Phase 6) */
+  saveDrawDeletions: boolean;
+  /** when true the factory suppresses local drawDeletions writes — server is authority */
+  auditAuthorityServer: boolean;
+  /** state of the loaded tournament records */
+  loaded: {
+    tournamentIds: string[];
+    currentTournamentId?: string;
+    /** lightweight counts across all loaded records */
+    counts: EngineInspectionCounts;
+  };
+  /** topics with at least one active subscription */
+  subscriptions: {
+    topics: string[];
+  };
+  /** current devContext (false when no dev logging is enabled) */
+  devContext: any;
+}
+
+function zeroCounts(): EngineInspectionCounts {
+  return {
+    tournaments: 0,
+    events: 0,
+    drawDefinitions: 0,
+    structures: 0,
+    matchUps: 0,
+    participants: 0,
+    venues: 0,
+    courts: 0,
+  };
+}
+
+function countLoadedRecords(records: Record<string, any>): EngineInspectionCounts {
+  const counts = zeroCounts();
+  for (const record of Object.values(records ?? {})) {
+    counts.tournaments += 1;
+    counts.events += record?.events?.length ?? 0;
+    counts.venues += record?.venues?.length ?? 0;
+    counts.participants += record?.participants?.length ?? 0;
+    for (const event of record?.events ?? []) {
+      counts.drawDefinitions += event?.drawDefinitions?.length ?? 0;
+      for (const dd of event?.drawDefinitions ?? []) {
+        counts.structures += dd?.structures?.length ?? 0;
+        for (const structure of dd?.structures ?? []) {
+          counts.matchUps += structure?.matchUps?.length ?? 0;
+        }
+      }
+    }
+    for (const venue of record?.venues ?? []) {
+      counts.courts += venue?.courts?.length ?? 0;
+    }
+  }
+  return counts;
+}
+
+export function inspect(): EngineInspection {
+  const records = getTournamentRecords() ?? {};
+  const tournamentIds = Object.keys(records);
+  const currentTournamentId = getTournamentId() || undefined;
+
+  const topicsResult = getTopics();
+  const topics: string[] = Array.isArray(topicsResult?.topics) ? topicsResult.topics : [];
+
+  return {
+    version: factoryVersion(),
+    schemaWriteMode: getSchemaWriteMode(),
+    saveDrawDeletions: getSaveDrawDeletions(),
+    auditAuthorityServer: getAuditAuthorityServer(),
+    loaded: {
+      tournamentIds,
+      currentTournamentId,
+      counts: countLoadedRecords(records),
+    },
+    subscriptions: { topics },
+    devContext: getDevContext(),
+  };
+}

--- a/src/forge/q.ts
+++ b/src/forge/q.ts
@@ -1,0 +1,182 @@
+/**
+ * engine.q — unwrap query facade (CODES Phase 5.x developer-JOY prototype #2)
+ *
+ * Every factory query returns a result envelope like `{ events, error }` or
+ * `{ event, drawDefinition, error }`. Consumers spend a lot of time writing
+ * `tournamentEngine.getEvents()?.events ?? []` boilerplate to dig the
+ * payload out.
+ *
+ * `engine.q` is a typed convenience layer that unwraps the primary payload
+ * for ~30 of the most-used queries. Each method returns the unwrapped value
+ * (or a sensible fallback if the underlying call errored or the key was
+ * missing) — never the envelope.
+ *
+ * Example:
+ *
+ *   // before
+ *   const events = tournamentEngine.getEvents()?.events ?? [];
+ *   const event  = tournamentEngine.getEvent({ eventId })?.event;
+ *
+ *   // after
+ *   const events = tournamentEngine.q.events();
+ *   const event  = tournamentEngine.q.event({ eventId });
+ *
+ * The original methods stay intact — `q` is purely additive. Consumers can
+ * opt in per-call-site without a breaking change.
+ *
+ * If a query returns multiple useful keys (e.g. `getEvent` returns `event`
+ * and `drawDefinition`), the registry can expose multiple facade names that
+ * call the same underlying method.
+ */
+
+type QueryRegistryEntry = {
+  /** factory engine method name to invoke */
+  method: string;
+  /** key on the result envelope to unwrap */
+  key: string;
+  /** fallback when the call errors or the key is missing */
+  fallback?: any;
+};
+
+/**
+ * Registry of facade name → underlying engine call. Curated from the top ~30
+ * queries by usage frequency across the CourtHive ecosystem consumers
+ * (TMX in particular). Extend over time; the cost of adding a new entry is
+ * one row in this map plus one signature on `QueryFacade`.
+ */
+const QUERY_REGISTRY: Record<string, QueryRegistryEntry> = {
+  // tournament-level
+  tournament: { method: 'getTournament', key: 'tournamentRecord' },
+  tournamentInfo: { method: 'getTournamentInfo', key: 'tournamentInfo' },
+  tournamentTimeItem: { method: 'getTournamentTimeItem', key: 'timeItem' },
+  linkedTournamentIds: { method: 'getLinkedTournamentIds', key: 'linkedTournamentIds' },
+  policyDefinitions: { method: 'getPolicyDefinitions', key: 'policyDefinitions' },
+  participants: { method: 'getParticipants', key: 'participants', fallback: [] },
+
+  // event-level
+  event: { method: 'getEvent', key: 'event' },
+  events: { method: 'getEvents', key: 'events', fallback: [] },
+  eventData: { method: 'getEventData', key: 'eventData' },
+  eventRankingPoints: { method: 'getEventRankingPoints', key: 'eventRankingPoints' },
+  flightProfile: { method: 'getFlightProfile', key: 'flightProfile' },
+
+  // draw-level
+  drawDefinition: { method: 'findDrawDefinition', key: 'drawDefinition' },
+  draftState: { method: 'getDraftState', key: 'draftState' },
+  publishState: { method: 'getPublishState', key: 'publishState' },
+  availablePlayoffProfiles: { method: 'getAvailablePlayoffProfiles', key: 'availablePlayoffProfiles', fallback: [] },
+  validGroupSizes: { method: 'getValidGroupSizes', key: 'validGroupSizes', fallback: [] },
+  assignedParticipantIds: { method: 'getAssignedParticipantIds', key: 'assignedParticipantIds', fallback: [] },
+  swissChart: { method: 'getSwissChart', key: 'swissChart' },
+  structureSeedAssignments: { method: 'getStructureSeedAssignments', key: 'seedAssignments', fallback: [] },
+  positionAssignments: { method: 'getPositionAssignments', key: 'positionAssignments', fallback: [] },
+
+  // matchUps
+  matchUp: { method: 'findMatchUp', key: 'matchUp' },
+  matchUps: { method: 'allTournamentMatchUps', key: 'matchUps', fallback: [] },
+  drawMatchUps: { method: 'allDrawMatchUps', key: 'matchUps', fallback: [] },
+  eventMatchUps: { method: 'allEventMatchUps', key: 'matchUps', fallback: [] },
+  competitionMatchUps: { method: 'getCompetitionMatchUps', key: 'matchUps', fallback: [] },
+  matchUpsMap: { method: 'getMatchUpsMap', key: 'matchUpsMap' },
+
+  // venues / courts
+  venue: { method: 'findVenue', key: 'venue' },
+  venuesAndCourts: { method: 'getVenuesAndCourts', key: 'venues', fallback: [] },
+
+  // PositionAssignment-level reads
+  tally: { method: 'getTally', key: 'tally' },
+
+  // extension passthrough (mode-agnostic via the underlying findExtension)
+  extension: { method: 'findExtension', key: 'extension' },
+
+  // CompetitionEngine surface — these only resolve when the underlying
+  // engine actually carries the method; otherwise the facade returns the
+  // fallback (undefined or []) and no crash.
+  competitionVenues: { method: 'getCompetitionVenues', key: 'venues', fallback: [] },
+  competitionParticipants: { method: 'getCompetitionParticipants', key: 'participants', fallback: [] },
+};
+
+/**
+ * Typed facade surface. Hand-maintained to give consumers IDE-discoverable
+ * methods with real return types. Per-method arg shapes are still `any`
+ * because the underlying engine methods are `any`-typed — tightening that
+ * is the natural follow-up (the joy-research "#1 typed signatures" item).
+ *
+ * IMPORTANT: Each method here MUST have a matching entry in QUERY_REGISTRY
+ * with the same key. The unit tests assert this invariant.
+ */
+export interface QueryFacade {
+  // tournament-level
+  tournament(args?: any): any;
+  tournamentInfo(args?: any): any;
+  tournamentTimeItem(args?: any): any;
+  linkedTournamentIds(args?: any): string[] | undefined;
+  policyDefinitions(args?: any): any;
+  participants(args?: any): any[];
+
+  // event-level
+  event(args?: any): any;
+  events(args?: any): any[];
+  eventData(args?: any): any;
+  eventRankingPoints(args?: any): any;
+  flightProfile(args?: any): any;
+
+  // draw-level
+  drawDefinition(args?: any): any;
+  draftState(args?: any): any;
+  publishState(args?: any): any;
+  availablePlayoffProfiles(args?: any): any[];
+  validGroupSizes(args?: any): any[];
+  assignedParticipantIds(args?: any): string[];
+  swissChart(args?: any): any;
+  structureSeedAssignments(args?: any): any[];
+  positionAssignments(args?: any): any[];
+
+  // matchUps
+  matchUp(args?: any): any;
+  matchUps(args?: any): any[];
+  drawMatchUps(args?: any): any[];
+  eventMatchUps(args?: any): any[];
+  competitionMatchUps(args?: any): any[];
+  matchUpsMap(args?: any): any;
+
+  // venues / courts
+  venue(args?: any): any;
+  venuesAndCourts(args?: any): any[];
+
+  // PositionAssignment-level
+  tally(args?: any): any;
+
+  // extension passthrough
+  extension(args?: any): any;
+
+  // competition engine surface
+  competitionVenues(args?: any): any[];
+  competitionParticipants(args?: any): any[];
+}
+
+/**
+ * Build the facade against an engine instance. Engine methods that are not
+ * present on the engine (e.g. CompetitionEngine-only methods on a tournament
+ * engine) silently fall back — no crash.
+ */
+export function buildQueryFacade(engine: any): QueryFacade {
+  const facade: any = {};
+  for (const [facadeName, entry] of Object.entries(QUERY_REGISTRY)) {
+    facade[facadeName] = (args?: any) => {
+      const fn = engine?.[entry.method];
+      if (typeof fn !== 'function') return entry.fallback;
+      const result = fn(args);
+      if (!result || result.error !== undefined) return entry.fallback;
+      const value = result[entry.key];
+      return value !== undefined ? value : entry.fallback;
+    };
+  }
+  return facade as QueryFacade;
+}
+
+/**
+ * Map of facade name → registry entry. Exported for tests + future
+ * documentation tooling.
+ */
+export const queryRegistry: Readonly<Record<string, QueryRegistryEntry>> = QUERY_REGISTRY;

--- a/src/tests/global/engineInspect.test.ts
+++ b/src/tests/global/engineInspect.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  setAuditAuthorityServer,
+  setSaveDrawDeletions,
+  setSchemaWriteMode,
+  setSubscriptions,
+} from '@Global/state/globalState';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+
+// constants and types
+import { LEGACY, NATIVE } from '@Constants/schemaWriteModeConstants';
+import { AUDIT, MODIFY_MATCHUP } from '@Constants/topicConstants';
+
+describe('engine.inspect — live state snapshot', () => {
+  it('reports the factory version + write-mode flags', () => {
+    tournamentEngine.reset();
+    setSchemaWriteMode(NATIVE);
+    setSaveDrawDeletions(false);
+    setAuditAuthorityServer(false);
+
+    const snap = tournamentEngine.inspect();
+    expect(typeof snap.version).toEqual('string');
+    expect(snap.version.length).toBeGreaterThan(0);
+    expect(snap.schemaWriteMode).toEqual(NATIVE);
+    expect(snap.saveDrawDeletions).toEqual(false);
+    expect(snap.auditAuthorityServer).toEqual(false);
+  });
+
+  it('reflects schemaWriteMode flips immediately', () => {
+    setSchemaWriteMode(LEGACY);
+    expect(tournamentEngine.inspect().schemaWriteMode).toEqual(LEGACY);
+    setSchemaWriteMode(NATIVE);
+    expect(tournamentEngine.inspect().schemaWriteMode).toEqual(NATIVE);
+    setSchemaWriteMode(LEGACY);
+  });
+
+  it('reports empty loaded state when nothing is set', () => {
+    tournamentEngine.reset();
+    const snap = tournamentEngine.inspect();
+    expect(snap.loaded.tournamentIds).toEqual([]);
+    expect(snap.loaded.currentTournamentId).toBeUndefined();
+    expect(snap.loaded.counts.tournaments).toEqual(0);
+    expect(snap.loaded.counts.events).toEqual(0);
+    expect(snap.loaded.counts.drawDefinitions).toEqual(0);
+    expect(snap.loaded.counts.matchUps).toEqual(0);
+    expect(snap.loaded.counts.participants).toEqual(0);
+  });
+
+  it('counts loaded records correctly', () => {
+    const result = mocksEngine.generateTournamentRecord({
+      inContext: true,
+      setState: true,
+      drawProfiles: [{ participantsCount: 8, drawSize: 8 }],
+      venueProfiles: [{ courtsCount: 4 }],
+    });
+
+    const snap = tournamentEngine.inspect();
+    expect(snap.loaded.tournamentIds).toContain(result.tournamentRecord.tournamentId);
+    expect(snap.loaded.currentTournamentId).toEqual(result.tournamentRecord.tournamentId);
+    expect(snap.loaded.counts.tournaments).toEqual(1);
+    expect(snap.loaded.counts.events).toBeGreaterThanOrEqual(1);
+    expect(snap.loaded.counts.drawDefinitions).toBeGreaterThanOrEqual(1);
+    expect(snap.loaded.counts.matchUps).toBeGreaterThan(0);
+    expect(snap.loaded.counts.participants).toBeGreaterThan(0);
+    expect(snap.loaded.counts.venues).toEqual(1);
+    expect(snap.loaded.counts.courts).toEqual(4);
+  });
+
+  it('reports subscribed topics', () => {
+    setSubscriptions({
+      subscriptions: {
+        [AUDIT]: () => {},
+        [MODIFY_MATCHUP]: () => {},
+      },
+    });
+    const snap = tournamentEngine.inspect();
+    expect(snap.subscriptions.topics).toContain(AUDIT);
+    expect(snap.subscriptions.topics).toContain(MODIFY_MATCHUP);
+    // cleanup
+    setSubscriptions({ subscriptions: { [AUDIT]: true, [MODIFY_MATCHUP]: true } });
+  });
+
+  it('returns the current devContext (false by default)', () => {
+    const snap = tournamentEngine.inspect();
+    expect(snap.devContext).toBeDefined();
+    // devContext is `false` by default (DevContextType union)
+    expect(snap.devContext === false || typeof snap.devContext === 'object').toEqual(true);
+  });
+
+  it('multiple loaded tournaments are all counted', () => {
+    tournamentEngine.reset();
+    const a = mocksEngine.generateTournamentRecord({ drawProfiles: [{ drawSize: 4 }] });
+    const b = mocksEngine.generateTournamentRecord({ drawProfiles: [{ drawSize: 4 }] });
+    tournamentEngine.setTournamentRecord(a.tournamentRecord);
+    tournamentEngine.setTournamentRecord(b.tournamentRecord);
+
+    const snap = tournamentEngine.inspect();
+    expect(snap.loaded.tournamentIds.length).toEqual(2);
+    expect(snap.loaded.counts.tournaments).toEqual(2);
+    expect(snap.loaded.counts.events).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/tests/global/queryFacade.test.ts
+++ b/src/tests/global/queryFacade.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildQueryFacade, queryRegistry } from '@Forge/index';
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+
+function seedTournament() {
+  const result = mocksEngine.generateTournamentRecord({
+    inContext: true,
+    setState: true,
+    drawProfiles: [{ participantsCount: 8, drawSize: 8 }],
+  });
+  return {
+    drawId: result.drawIds[0],
+    eventId: result.eventIds[0],
+    tournamentRecord: result.tournamentRecord,
+  };
+}
+
+describe('engine.q — unwrap query facade', () => {
+  it('exposes a typed facade object on the engine', () => {
+    expect(typeof tournamentEngine.q).toEqual('object');
+    expect(typeof tournamentEngine.q.events).toEqual('function');
+    expect(typeof tournamentEngine.q.event).toEqual('function');
+    expect(typeof tournamentEngine.q.tournament).toEqual('function');
+  });
+
+  it('q.events() returns the array directly with [] fallback', () => {
+    seedTournament();
+    const events = tournamentEngine.q.events();
+    expect(Array.isArray(events)).toEqual(true);
+    expect(events.length).toEqual(1);
+  });
+
+  it('q.events() returns [] when no state is loaded', () => {
+    tournamentEngine.reset();
+    const events = tournamentEngine.q.events();
+    expect(events).toEqual([]);
+  });
+
+  it('q.event({ eventId }) returns the event directly, undefined when missing', () => {
+    const { eventId } = seedTournament();
+    const event = tournamentEngine.q.event({ eventId });
+    expect(event?.eventId).toEqual(eventId);
+    expect(tournamentEngine.q.event({ eventId: 'no-such-event' })).toBeUndefined();
+  });
+
+  it('q.tournament() returns the loaded tournamentRecord, undefined when none', () => {
+    tournamentEngine.reset();
+    expect(tournamentEngine.q.tournament()).toBeUndefined();
+    const { tournamentRecord } = seedTournament();
+    const record = tournamentEngine.q.tournament();
+    expect(record?.tournamentId).toEqual(tournamentRecord.tournamentId);
+  });
+
+  it('q.participants() returns the array directly with [] fallback', () => {
+    seedTournament();
+    const participants = tournamentEngine.q.participants();
+    expect(Array.isArray(participants)).toEqual(true);
+    expect(participants.length).toBeGreaterThan(0);
+  });
+
+  it('q.matchUps() returns the array directly with [] fallback', () => {
+    seedTournament();
+    const matchUps = tournamentEngine.q.matchUps();
+    expect(Array.isArray(matchUps)).toEqual(true);
+    expect(matchUps.length).toBeGreaterThan(0);
+  });
+
+  it('q.drawMatchUps({ drawId }) returns the array directly', () => {
+    const { drawId } = seedTournament();
+    const matchUps = tournamentEngine.q.drawMatchUps({ drawId });
+    expect(Array.isArray(matchUps)).toEqual(true);
+    expect(matchUps.length).toBeGreaterThan(0);
+  });
+
+  it('q.drawDefinition({ drawId }) returns the drawDefinition directly', () => {
+    const { drawId } = seedTournament();
+    const dd = tournamentEngine.q.drawDefinition({ drawId });
+    expect(dd?.drawId).toEqual(drawId);
+  });
+
+  it('returns the fallback when a method is missing on the engine', () => {
+    // simulate a method that doesn't exist by calling against a facade built
+    // on a stub engine
+    const stubFacade = buildQueryFacade({});
+    expect(stubFacade.events()).toEqual([]);
+    expect(stubFacade.event({ eventId: 'x' })).toBeUndefined();
+    expect(stubFacade.participants()).toEqual([]);
+  });
+
+  it('returns the fallback when the underlying method returns an error envelope', () => {
+    const stubEngine: any = {
+      getEvents: () => ({ error: { code: 'BOOM' } }),
+      getEvent: () => ({ error: { code: 'NOT_FOUND' } }),
+    };
+    const stubFacade = buildQueryFacade(stubEngine);
+    expect(stubFacade.events()).toEqual([]);
+    expect(stubFacade.event({ eventId: 'x' })).toBeUndefined();
+  });
+
+  it('every QueryFacade method has a queryRegistry entry (invariant)', () => {
+    // The TypeScript QueryFacade interface and the runtime registry must
+    // agree. Iterate the facade and assert every key resolves to a function.
+    const facade: any = tournamentEngine.q;
+    const facadeKeys = Object.keys(facade);
+    for (const key of facadeKeys) {
+      expect(typeof facade[key]).toEqual('function');
+      expect(queryRegistry[key]).toBeDefined();
+    }
+    // Sanity floor — we ship at least 25 unwrap helpers in the prototype.
+    expect(facadeKeys.length).toBeGreaterThanOrEqual(25);
+  });
+});

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -367,6 +367,7 @@ export type FactoryEngineMethod =
   | 'inferServeSide'
   | 'initializeCompetitionState'
   | 'initializeDraft'
+  | 'inspect'
   | 'intervalsOverlap'
   | 'isAdHoc'
   | 'isAggregateFormat'
@@ -972,6 +973,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'inferServeSide',
   'initializeCompetitionState',
   'initializeDraft',
+  'inspect',
   'intervalsOverlap',
   'isAdHoc',
   'isAggregateFormat',

--- a/src/types/factoryTypes.ts
+++ b/src/types/factoryTypes.ts
@@ -46,7 +46,20 @@ export type FactoryEngine = {
  *   import { tournamentEngine, FactoryEngineTyped } from 'tods-competition-factory';
  *   const engine = tournamentEngine as FactoryEngineTyped;
  */
-export type FactoryEngineTyped = Record<FactoryEngineMethod, (...args: any[]) => any>;
+export type FactoryEngineTyped = Record<FactoryEngineMethod, (...args: any[]) => any> & {
+  /**
+   * Developer-JOY unwrap query facade — see `src/forge/q.ts`.
+   *
+   * Returns the unwrapped primary payload of common queries directly:
+   *
+   *   const events = engine.q.events();          // Event[]
+   *   const event  = engine.q.event({ eventId }); // Event | undefined
+   *
+   * Replaces the `tournamentEngine.getEvents()?.events ?? []` boilerplate.
+   * Per-method arg shapes are still `any`; typed signatures are a follow-up.
+   */
+  q: import('../forge').QueryFacade;
+};
 
 export type { FactoryEngineMethod } from './factoryEngineMethods';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
       "@Constants/*": ["./src/constants/*"],
       "@Functions/*": ["./src/functions/*"],
       "@Fixtures/*": ["./src/fixtures/*"],
+      "@Forge/*": ["./src/forge/*"],
       "@Acquire/*": ["./src/acquire/*"],
       "@Helpers/*": ["./src/helpers/*"],
       "@Global/*": ["./src/global/*"],

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -55,6 +55,7 @@ export default defineConfig({
       '@Constants': new URL('./src/constants', import.meta.url).pathname,
       '@Functions': new URL('./src/functions', import.meta.url).pathname,
       '@Fixtures': new URL('./src/fixtures', import.meta.url).pathname,
+      '@Forge': new URL('./src/forge', import.meta.url).pathname,
       '@Acquire': new URL('./src/acquire', import.meta.url).pathname,
       '@Helpers': new URL('./src/helpers', import.meta.url).pathname,
       '@Global': new URL('./src/global', import.meta.url).pathname,


### PR DESCRIPTION
## Summary

Two small, additive developer-experience helpers — the top-2 picks from the [factory developer JOY research](https://github.com/CourtHive/Mentat/blob/main/planning/FACTORY_DEVELOPER_JOY.md). Both live in the `forge/` namespace, both wired through `engineStart`, both purely additive.

## engine.q — unwrap query facade (#2 from the JOY list)

Returns the primary payload of common queries directly. Replaces the `tournamentEngine.getEvents()?.events ?? []` boilerplate that appears 87+ times in TMX.

\`\`\`ts
// before
const events = tournamentEngine.getEvents()?.events ?? [];
const event  = tournamentEngine.getEvent({ eventId })?.event;
const draft  = tournamentEngine.getDraftState({ drawId })?.draftState;

// after
const events = tournamentEngine.q.events();
const event  = tournamentEngine.q.event({ eventId });
const draft  = tournamentEngine.q.draftState({ drawId });
\`\`\`

**30 facade methods** spanning the top-used queries by frequency across TMX: \`tournament\`, \`tournamentInfo\`, \`participants\`, \`event\`, \`events\`, \`eventData\`, \`flightProfile\`, \`drawDefinition\`, \`draftState\`, \`publishState\`, \`matchUp\`, \`matchUps\`, \`drawMatchUps\`, \`eventMatchUps\`, \`competitionMatchUps\`, \`venue\`, \`venuesAndCourts\`, \`tally\`, \`extension\`, \`linkedTournamentIds\`, \`policyDefinitions\`, \`validGroupSizes\`, \`assignedParticipantIds\`, \`swissChart\`, \`structureSeedAssignments\`, \`positionAssignments\`, \`matchUpsMap\`, \`availablePlayoffProfiles\`, \`tournamentTimeItem\`, \`eventRankingPoints\`, \`competitionVenues\`, \`competitionParticipants\`.

\`FactoryEngineTyped\` intersected with \`{ q: QueryFacade }\` so consumers using the typed cast get \`q.*\` autocomplete and real return types (per-method arg shapes are still \`any\` — tightening that is the natural follow-up, #1 on the JOY list).

Engine methods absent on a particular instance (e.g. CompetitionEngine-only methods called on the tournament engine) gracefully fall back to the registered fallback value (\`[]\`, \`undefined\`).

## engine.inspect (#8 from the JOY list)

Side-effect-free snapshot of the engine's live state — meant for \`console.log(engine.inspect())\`, bug-report pastes, devtools panels.

\`\`\`ts
engine.inspect() === {
  version: '5.0.0-alpha.0',
  schemaWriteMode: 'native',
  saveDrawDeletions: false,
  auditAuthorityServer: false,
  loaded: {
    tournamentIds: ['t-1', 't-2'],
    currentTournamentId: 't-1',
    counts: {
      tournaments: 2, events: 4, drawDefinitions: 4, structures: 4,
      matchUps: 124, participants: 64, venues: 1, courts: 4,
    },
  },
  subscriptions: { topics: ['AUDIT', 'MODIFY_MATCHUP'] },
  devContext: false,
};
\`\`\`

## Plumbing

- New \`@Forge\` path alias in \`tsconfig.json\` + \`vitest.config.mts\`
- \`factoryEngineMethods.ts\` regenerated — 604 methods (\`inspect\` added; \`q\` is an object, correctly skipped by the generator)
- \`factoryTypes.ts\` uses a relative \`import('../forge')\` for \`QueryFacade\` so the rollup-emitted \`dist/*.d.ts\` inlines the type rather than emitting an unresolvable \`@Forge/index\` import for consumers

## Verification

- \`pnpm check-types\` — green
- \`pnpm lint\` — green
- \`pnpm test --run\` — 922 files / 9640 pass / 7 skip / 0 fail (+3 files / +19 tests vs baseline)
- \`pnpm build\` — green; \`dist/*.d.ts\` correctly inlines \`QueryFacade\`

## What's next (not in this PR)

- \`engine.dryRun()\` — #3 on the JOY list; reuses the rollback machinery already in \`executionQueue\`
- Typed per-method signatures — #1; \`q\` is now the natural chokepoint
- TMX migration of the 87 \`?.events ?? []\` sites to \`engine.q.events()\` — separate PR; mechanical but volume-heavy

## Test plan

- [ ] CI green
- [ ] release-please PR #4383 picks up both commits under Features in the 5.0.0 changelog
- [ ] Try \`tournamentEngine.q.events()\` and \`tournamentEngine.inspect()\` in a fresh consumer; confirm IDE autocomplete shows the facade methods