### PR TITLE
fix(schedule): scheduledMatchUpDate reads first-class with timeItem fallback

### DIFF
--- a/src/query/matchUp/scheduledMatchUpDate.ts
+++ b/src/query/matchUp/scheduledMatchUpDate.ts
@@ -4,11 +4,21 @@ import { latestVisibleTimeItemValue } from '@Query/matchUp/latestVisibleTimeItem
 import { SCHEDULED_DATE } from '@Constants/timeItemConstants';
 import { ScheduledMatchUpArgs } from '@Types/factoryTypes';
 
+/**
+ * CODES Phase 2 promoted `SCHEDULED_DATE` from `matchUp.timeItems[]` to the
+ * first-class attribute `matchUp.schedule.scheduledDate`. Prefer the
+ * first-class value; fall back to the legacy timeItem only when first-class
+ * isn't populated (pre-CODES records that haven't been migrated yet).
+ */
 export function scheduledMatchUpDate({ timeStamp, schedule, matchUp }: ScheduledMatchUpArgs) {
-  const { itemValue: scheduledDate, timeStamp: itemTimeStamp } = latestVisibleTimeItemValue({
+  const firstClassDate = matchUp?.schedule?.scheduledDate;
+
+  const { itemValue: legacyDate, timeStamp: itemTimeStamp } = latestVisibleTimeItemValue({
     timeItems: matchUp?.timeItems ?? [],
     itemType: SCHEDULED_DATE,
   });
+
+  const scheduledDate = firstClassDate ?? legacyDate;
 
   return !schedule || (itemTimeStamp && timeStamp && new Date(itemTimeStamp).getTime() > new Date(timeStamp).getTime())
     ? { scheduledDate }


### PR DESCRIPTION
## Summary

CODES Phase 2 promoted \`SCHEDULED_DATE\` from \`matchUp.timeItems[]\` to the first-class \`matchUp.schedule.scheduledDate\` attribute, but \`src/query/matchUp/scheduledMatchUpDate.ts\` was missed in that migration — it was still reading the legacy timeItem only.

Under 5.0.0 NATIVE-default writes, the legacy timeItem is no longer populated, so \`scheduledMatchUpDate({ matchUp })\` returned \`undefined\` even when the matchUp had \`schedule.scheduledDate\` set. This silently degraded:

- the schedule2 active-strip path (TBP matchUps did not surface as NEXT, IN_PROGRESS as LIVE)
- \`filterMatchUps\` (matchUps with native-written scheduledDate did not appear in date-filtered results)
- \`getMatchUpScheduleDetails\` (line 115 uses scheduledMatchUpDate)
- \`getTournamentInfo\` dateRange resolution (line 163)

Surfaced via TMX e2e tests (Journey 29 schedule2 active strip) that were failing the "scheduled TBP matchUp surfaces on its court as NEXT" assertion against \`main\`. The user correctly flagged that consumers shouldn't be writing in DUAL mode to work around stale factory readers — the fix is on the factory side.

## What changes

\`src/query/matchUp/scheduledMatchUpDate.ts\` — prefer \`matchUp.schedule.scheduledDate\` first; fall back to the legacy timeItem when the first-class field is unset (pre-CODES records that haven't been through \`migrateTournamentRecord\`). Standard CODES read pattern, identical in spirit to \`firstClassOrExtension\` / \`firstClassOrTimeItem\`.

## Verification

- \`pnpm check-types\` — green
- \`pnpm lint\` — green
- \`pnpm test --run\` — 922 files / 9640 pass / 7 skip / 0 fail (no regressions)
- \`pnpm build\` — green

## Test plan

- [ ] CI green
- [ ] TMX e2e Journey 29 active strip tests pass against NATIVE-mode writes (validated locally — see companion TMX PR)