### PR TITLE
feat(engines): export competitionEngineAsync + tournamentEngineAsync

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,15 @@ export { officiatingEngine } from './assemblies/engines/officiating';
 // reliance — same runtime singleton, looser type).
 export { competitionEngine, tournamentEngine } from './tests/engines/syncEngine';
 export { competitionEngineUntyped, tournamentEngineUntyped } from './tests/engines/syncEngine';
+// Async variants — same governor surface as competitionEngine /
+// tournamentEngine, but built atop `asyncEngine()` so each consumer
+// gets per-request state isolation via Node's async_hooks. Use these
+// where a sync singleton would risk cross-request contamination —
+// e.g. CFS executionQueue helpers that need findMatchUp on a record
+// fetched under a per-tournament lock. The bare `asyncEngine()`
+// factory remains exported for callers that want to assemble a
+// custom governor set themselves.
+export { competitionEngineAsync, tournamentEngineAsync } from './tests/engines/asyncEngine';
 
 // FIXTURES --------------------------------------------------------------
 export { fixtures } from './fixtures';


### PR DESCRIPTION
## Summary

- Re-exports `competitionEngineAsync` and `tournamentEngineAsync` from `src/index.ts`. Both already existed inside `src/tests/engines/asyncEngine/index.ts` — this just promotes them to the public surface.
- The bare `asyncEngine()` function continues to be exported for callers that want to assemble a custom governor set. This change adds the pre-assembled \"full governor surface\" pair so downstream consumers don't have to.

## Why

CFS executionQueue helpers — notably `resolveMatchUpReferences` (added 2026-06-01) — need `findMatchUp` on a tournament record fetched under a per-tournament lock. The current implementation uses the sync `tournamentEngine` singleton and relies on a read-only invariant:

> No other `src/` code uses the sync engine on the same hot path.

That invariant is fragile by design. Any future contributor adding a sync read elsewhere risks cross-request contamination, since the singleton's `setState(...)` mutates process-wide state. The proper fix is per-call isolation via `async_hooks`, but the factory's public `asyncEngine()` is the bare-engine variant — no `findMatchUp`, no other governor methods.

The shape we actually want is what the factory's own test surface already constructs:

```ts
// factory/src/tests/engines/asyncEngine/index.ts
const asyncEngine = async(true);
asyncEngine.importMethods(governors, true, 1);
export const competitionEngineAsync = asyncEngine;
export const tournamentEngineAsync = asyncEngine;
```

This PR makes those pre-assembled exports reachable from `tods-competition-factory`'s public index so CFS can switch its sync-singleton call sites without resorting to a workaround.

## Test plan

- [x] No `src/` changes — re-export only, no runtime behavior added.
- [x] The two exported bindings are already constructed and exercised by the factory's own coverage tests (`src/tests/refactoring/smallModuleCoverage.test.ts:6` imports `@Engines/asyncEngine`).
- [ ] CI (existing matrix runs against the new public surface).
- [ ] Downstream verification: a follow-up CFS commit will swap `executionQueue.resolveMatchUpReferences`'s `tournamentEngine.setState(...).findMatchUp(...)` to `tournamentEngineAsync.setState(...).findMatchUp(...)` once this lands and the factory bump propagates.