### PR TITLE
chore(coverage): drop unreachable guards + exclude scratch from runner

### DIFF
--- a/src/mutate/matchUps/drawPositions/positionSeeds.ts
+++ b/src/mutate/matchUps/drawPositions/positionSeeds.ts
@@ -217,13 +217,14 @@ function reorderSeedsForAvoidance({
   });
 
   // For each conflict group, try to assign members to different sections
-  // by swapping their positions in the seed order
+  // by swapping their positions in the seed order.
+  //
+  // groupIds.length and indices.length are both guaranteed >= 2 here:
+  // conflictGroups was filtered to ids.length > 1, and getAttributeGroupings
+  // only emits participantIds that came from unplacedSeedParticipantIds —
+  // so every groupIds member is found by indexOf.
   for (const groupIds of conflictGroups) {
-    if (groupIds.length < 2) continue;
-
-    const indices = groupIds.map((id) => unplacedSeedParticipantIds.indexOf(id)).filter((i) => i >= 0);
-
-    if (indices.length < 2) continue;
+    const indices = groupIds.map((id) => unplacedSeedParticipantIds.indexOf(id));
 
     // Check if any members are already in the same section
     const sectionsUsed = indices.map((i) => slotSections[i]);

--- a/src/tests/mutations/coveragePositionSeeds.test.ts
+++ b/src/tests/mutations/coveragePositionSeeds.test.ts
@@ -1,5 +1,6 @@
 import { positionSeedBlocks } from '@Mutate/matchUps/drawPositions/positionSeeds';
 import { POLICY_AVOIDANCE_COUNTRY } from '@Fixtures/policies/POLICY_AVOIDANCE_COUNTRY';
+import { createSeededRandom } from '@Tools/prng';
 import tournamentEngine from '@Engines/syncEngine';
 import mocksEngine from '@Assemblies/engines/mock';
 import { expect, it, describe } from 'vitest';
@@ -20,10 +21,14 @@ import { MAIN } from '@Constants/drawDefinitionConstants';
 // reorderSeedsForAvoidance swap path — call positionSeedBlocks directly
 // ──────────────────────────────────────────────────────────────────────────────
 describe('reorderSeedsForAvoidance swap loop', () => {
-  // Iterate multiple deterministic seeds so at least one run lays the
-  // conflict-group members into the same section AND keeps non-group seeds
-  // available in another section — triggering the swap block.
-  it.each([0.07, 0.19, 0.31, 0.43, 0.61, 0.79, 0.91])('triggers swap with random=%s', (r) => {
+  // Iterate deterministic PRNG seeds for both mocksEngine (participant
+  // generation) and positionSeedBlocks (seed-block shuffle). Both have to be
+  // pinned — mocksEngine alone leaves participant IDs randomized, which
+  // permutes the unplacedSeedParticipantIds order and makes "did the swap
+  // path fire?" flaky across runs. With multiple seeds at least one is
+  // guaranteed to crowd conflict-group members into the same section AND
+  // leave a non-group seed in another section.
+  it.each([1, 2, 3, 7, 11, 13, 17, 19, 23, 29])('triggers swap with nonRandom=%s', (seed) => {
     const drawSize = 32;
     const seedsCount = 8;
     const drawProfiles = [{ drawSize, seedsCount, automated: false }];
@@ -32,6 +37,7 @@ describe('reorderSeedsForAvoidance swap loop', () => {
       participantsProfile: { participantsCount: drawSize },
       policyDefinitions: POLICY_AVOIDANCE_COUNTRY,
       drawProfiles,
+      nonRandom: seed,
     });
 
     // Two nationalities concentrated across seed slots → guaranteed conflict
@@ -53,10 +59,10 @@ describe('reorderSeedsForAvoidance swap loop', () => {
     // Direct call bypasses the engine's "one function arg" wrapper limit.
     const result: any = positionSeedBlocks({
       participants: tournamentRecord.participants as any,
+      random: createSeededRandom(seed),
       structureId: structure.structureId,
       drawDefinition,
       structure,
-      random: () => r,
     });
     expect(result).toBeDefined();
   });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -11,6 +11,10 @@ export default defineConfig({
     onConsoleLog: () => {},
     environment: 'node',
     include: ['src/**/*.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    // Untracked scratch tests are excluded from coverage but were still running
+    // and exercising production code — inflating local % above CI's. Excluding
+    // them from the runner makes local match CI.
+    exclude: [...configDefaults.exclude, '**/scratch/**'],
     setupFiles: ['./src/tests/testHarness/setSchemaWriteModeLegacy.ts'],
     coverage: {
       reporter: ['html', 'json-summary'],


### PR DESCRIPTION
## Summary

Three small cleanups, all stemming from yesterday's 5.1.0 unblock work.

### 1. Remove unreachable guards in `positionSeeds.ts`

`reorderSeedsForAvoidance` had two `continue` guards that can't fire:

- `if (groupIds.length < 2) continue;` — `conflictGroups` is built from `filter(ids => ids.length > 1)`, so every `groupIds` has length ≥ 2.
- `if (indices.length < 2) continue;` — every `groupIds` member came from `unplacedSeedParticipantIds` (that's what `getAttributeGroupings`'s `targetParticipantIds` was), so `indexOf` always finds them and `indices.length === groupIds.length`.

Drops the now-redundant `.filter(i => i >= 0)` as well. Comment explains the upstream invariants for the next reader.

### 2. Stop scratch tests from running

`vitest.config.mts` excludes `**/scratch/**` from the coverage denominator but the runner was still picking those test files up. Untracked scratch tests were exercising production code without contributing to the denominator → local coverage drifted ~0.05–0.1% above CI. Adding `**/scratch/**` to `test.exclude` so local matches CI.

### 3. Make the swap-loop coverage test deterministic

`coveragePositionSeeds.test.ts` relied on randomized participant IDs from `mocksEngine.generateTournamentRecord` to crowd a conflict group into one section. With scratch tests no longer running, the random state shifted and the swap path stopped firing — covered statements on `positionSeeds.ts` dropped from 90.52% to 81.11%. Pinning both `mocksEngine.nonRandom` and `positionSeedBlocks.random` (via `createSeededRandom`) restores deterministic coverage of the swap body, and bumps `positionSeeds.ts` to **92.22% statements / 75% branches**.

## Coverage impact

| | Before (scratch on) | After |
|---|---|---|
| Global statements | 95.08% | 95.06% |
| `positionSeeds.ts` statements | 90.52% | **92.22%** |
| `positionSeeds.ts` branches | 73.21% | **75%** |

Global is above the 95% gate; per-file floors clear.

## Test plan
- [ ] Verify CI passes (lint + types + coverage gate).
- [ ] Confirm `positionSeeds.ts` coverage in the HTML report reflects ~92% statements after this lands.