### PR TITLE
fix(query): preserve hydrated schedule under NATIVE mode (matchUp.schedule clobber)

### DIFF
--- a/src/query/matchUps/addMatchUpContext.ts
+++ b/src/query/matchUps/addMatchUpContext.ts
@@ -79,8 +79,7 @@ type AddMatchUpContextArgs = {
 function applyEmbargoFilter({ publishStatus, drawDefinition, structure, matchUp, schedule }) {
   if (!publishStatus || !drawDefinition?.drawId || !structure?.structureId) return schedule;
 
-  const structDetail =
-    publishStatus?.drawDetails?.[drawDefinition.drawId]?.structureDetails?.[structure.structureId];
+  const structDetail = publishStatus?.drawDetails?.[drawDefinition.drawId]?.structureDetails?.[structure.structureId];
   if (!structDetail) return schedule;
 
   const rn = matchUp.roundNumber;
@@ -245,6 +244,29 @@ export function addMatchUpContext({
   // order is important here as Round Robin matchUps already have inContext structureId
   const onlyDefined = (obj) => definedAttributes(obj, undefined, true);
 
+  // CODES Phase 2 promoted `matchUp.schedule.*` to first-class. The source
+  // matchUp now carries its own `schedule` object, and a naive spread of
+  // `makeDeepCopy(matchUp)` would *replace* the hydrated `schedule` (with
+  // derived venueName / courtName / venueAbbreviation / isoDateString /
+  // milliseconds / time + any embargo/publishStatus filtering applied) —
+  // losing all the derived fields whenever the source has a non-empty
+  // first-class schedule object.
+  //
+  // Strip schedule from the source spread and merge it onto the hydrated
+  // schedule explicitly. Source-side first-class fields the hydrator
+  // doesn't yet know about (e.g. `calledAt`) come through via the
+  // base layer; hydrated-side derived names + applied filters win where
+  // they overlap.
+  //
+  // Also closes a privacy leak in the embargo path: when
+  // `applyEmbargoFilter` zeroed the hydrated schedule to undefined, the
+  // source schedule used to leak through; now it gets dropped entirely
+  // unless something explicitly merged it back in.
+  const sourceMatchUp = makeDeepCopy(onlyDefined(matchUp), true, true);
+  const sourceSchedule = sourceMatchUp.schedule;
+  delete sourceMatchUp.schedule;
+  const mergedSchedule = schedule ? { ...(sourceSchedule ?? {}), ...schedule } : schedule;
+
   const matchUpWithContext = {
     ...onlyDefined(context),
     ...onlyDefined({
@@ -276,11 +298,11 @@ export function addMatchUpContext({
       roundName,
       drawName,
       drawType,
-      schedule,
+      schedule: mergedSchedule,
       drawId,
       stage,
     }),
-    ...makeDeepCopy(onlyDefined(matchUp), true, true),
+    ...sourceMatchUp,
   };
 
   if (matchUpFormat && matchUp.score?.scoreStringSide1) {
@@ -459,7 +481,17 @@ function buildMatchUpSides({
   });
 }
 
-function hydrateSides({ tournamentParticipants, hydrateParticipants, positionAssignments, appliedPolicies, drawDefinition, participantMap, contextProfile, matchUpWithContext, event }) {
+function hydrateSides({
+  tournamentParticipants,
+  hydrateParticipants,
+  positionAssignments,
+  appliedPolicies,
+  drawDefinition,
+  participantMap,
+  contextProfile,
+  matchUpWithContext,
+  event,
+}) {
   const participantAttributes = appliedPolicies?.[POLICY_TYPE_PARTICIPANT];
   const getMappedParticipant = (participantId) => {
     const participant = participantMap?.[participantId]?.participant;
@@ -505,7 +537,17 @@ function hydrateSides({ tournamentParticipants, hydrateParticipants, positionAss
   });
 }
 
-function hydrateSideParticipant({ side, getMappedParticipant, tournamentParticipants, hydrateParticipants, positionAssignments, appliedPolicies, drawDefinition, contextProfile, event }) {
+function hydrateSideParticipant({
+  side,
+  getMappedParticipant,
+  tournamentParticipants,
+  hydrateParticipants,
+  positionAssignments,
+  appliedPolicies,
+  drawDefinition,
+  contextProfile,
+  event,
+}) {
   if (!side.participantId) return;
 
   const participant = makeDeepCopy(

--- a/src/tests/queries/matchUps/scheduleHydrationRegression.test.ts
+++ b/src/tests/queries/matchUps/scheduleHydrationRegression.test.ts
@@ -12,9 +12,12 @@
  * in the same PR — these are part of the public API contract of the
  * server's scheduled-matchups response.
  */
+import { setSchemaWriteMode } from '@Global/state/globalState';
 import mocksEngine from '@Assemblies/engines/mock';
 import tournamentEngine from '@Engines/syncEngine';
 import { describe, expect, it } from 'vitest';
+
+import { NATIVE, DUAL, LEGACY, SchemaWriteMode } from '@Constants/schemaWriteModeConstants';
 
 function scheduleOneMatchUp(opts: { startDate: string }) {
   const venueProfiles = [
@@ -206,3 +209,48 @@ describe('competitionScheduleMatchUps — public API shape', () => {
     expect(venue?.courts?.find((c: any) => c.courtId === courtId)?.courtId).toEqual(courtId);
   });
 });
+
+/**
+ * Regression for the IONSport bug. CODES Phase 2 promoted
+ * `matchUp.schedule.*` to a first-class object on the source matchUp. In
+ * `addMatchUpContext` the original spread order was:
+ *
+ *   { ...context, ...{ ..., schedule, ... }, ...makeDeepCopy(matchUp) }
+ *
+ * Under LEGACY mode the source `matchUp.schedule` is undefined, so the
+ * hydrated schedule from the second spread survived — which is what the
+ * default vitest setup pins, and what the rest of this test file
+ * exercises. Under NATIVE (production default) and DUAL the source
+ * `matchUp.schedule` is non-empty, so the third spread fully replaced
+ * the hydrated `schedule` — losing every derived field (`venueName`,
+ * `courtName`, `venueAbbreviation`, `isoDateString`, `milliseconds`,
+ * `time`, recovery times) and also bypassing the embargo / publish-state
+ * filtering the hydrator had applied.
+ *
+ * The fix in `addMatchUpContext` strips `schedule` from the source spread
+ * and merges any source-only first-class fields (e.g. `calledAt`) onto
+ * the hydrated schedule explicitly. This describe-block locks down that
+ * behaviour under all three schema-write modes so the bug can't recur on
+ * a future shape promotion.
+ */
+describe.each([NATIVE, DUAL, LEGACY] as SchemaWriteMode[])(
+  'schedule hydration survives matchUp.schedule first-class clobber (mode=%s)',
+  (mode) => {
+    it('keeps venueName + courtName on dateMatchUps[].schedule', () => {
+      setSchemaWriteMode(mode);
+      const startDate = '2026-06-06';
+      const { matchUpId, venueName, courtName, venueId, courtId } = scheduleOneMatchUp({ startDate });
+
+      const result = tournamentEngine.competitionScheduleMatchUps({
+        matchUpFilters: { scheduledDate: startDate },
+        usePublishState: false,
+      });
+      const target = result.dateMatchUps.find((m: any) => m.matchUpId === matchUpId);
+
+      expect(target?.schedule?.venueId).toEqual(venueId);
+      expect(target?.schedule?.courtId).toEqual(courtId);
+      expect(target?.schedule?.venueName).toEqual(venueName);
+      expect(target?.schedule?.courtName).toEqual(courtName);
+    });
+  },
+);


### PR DESCRIPTION
## Summary
**Production bug** observed via IONSport on courthive-public's `/factory/scheduledmatchups` endpoint: matchUp `schedule` returns only `{ venueId, courtId, courtOrder, scheduledDate, scheduledTime }` — losing `venueName`, `courtName`, `venueAbbreviation`, `isoDateString`, `milliseconds`, `time`, recovery times, AND bypassing the publish-state / embargo filter the hydrator had applied.

## Root cause
CODES Phase 2 (`86190665b`) promoted `matchUp.schedule.*` to a first-class object on the source matchUp. `addMatchUpContext` builds `matchUpWithContext` as:

```ts
{ ...context, ...{ ..., schedule /* hydrated */, ... }, ...makeDeepCopy(matchUp) }
```

The third spread fully replaces the `schedule` key whenever the source matchUp carries a non-empty schedule object — i.e. under NATIVE (prod default) and DUAL. Under LEGACY (vitest setupFiles default — `src/tests/testHarness/setSchemaWriteModeLegacy.ts:20-24`) `matchUp.schedule` stays undefined so the third spread had no `schedule` key, and the hydrated schedule from the second spread survived. **That mode pinning is why the regression test merged in #4422 was a false negative.** It exercised LEGACY only.

## Fix
Strip `schedule` from the source spread and merge it onto the hydrated schedule explicitly. The hydrator already reads every first-class schedule field source-side, so source-side fields the hydrator knows about are duplicated either way; source-only first-class fields the hydrator doesn't yet know about (e.g. `matchUp.schedule.calledAt` written by `setMatchUpCalledAt`) come through via the base-layer merge.

Side-effect: closes a privacy leak in the embargo path. When `applyEmbargoFilter` zeroed the hydrated schedule to `undefined`, the source schedule used to leak through the third spread, defeating the embargo. Now the source schedule is dropped entirely unless the hydrator returned one.

## Regression test
Extended `scheduleHydrationRegression.test.ts` with a mode-parameterized describe block (`NATIVE | DUAL | LEGACY`) asserting `schedule.venueName` and `schedule.courtName` survive end-to-end. The earlier LEGACY-only block is preserved as-is.

## Diagnosis evidence
Direct read against prod Postgres confirmed: tournament `ccb37afb-…` has the venue `8465e143-…` with all 19 courts properly named (`Court 1` through `Court 19`), and the matchUp record on disk has exactly the same 5-field `schedule` object as the response IONSport received — so the bug is the hydrator wholesale-replacement, not missing data on prod.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm check-types`
- [x] Full factory suite: 9867/9867 pass, 3 skipped (pre-existing)
- [ ] Cut a patch release; bump CFS + courthive-public + TMX
- [ ] After bump deploy: hit `/factory/scheduledmatchups` for tournament `ccb37afb-…` and confirm IONSport sees `venueName: "Rick Macci Tennis Academy"` and `courtName: "Court N"` on each scheduled matchUp