### PR TITLE
feat(sync): port nonRandom middleware from mocksEngine to syncEngine

### DIFF
--- a/src/assemblies/engines/sync/engineInvoke.ts
+++ b/src/assemblies/engines/sync/engineInvoke.ts
@@ -6,6 +6,7 @@ import { notifySubscribers } from '@Global/state/notifySubscribers';
 import { setState } from '@Assemblies/engines/parts/stateMethods';
 import { isFunction, isObject, isString } from '@Tools/objects';
 import { getMethods } from '@Global/state/syncGlobalState';
+import { createSeededRandom } from '@Tools/prng';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
 
 // constants
@@ -27,6 +28,17 @@ export function engineInvoke(engine: { [key: string]: any }, args: any) {
 
   const { [methodName]: passedMethod, ...remainingArgs } = args;
   const params = args?.params ? { ...args.params } : { ...remainingArgs };
+
+  // nonRandom: <seed> middleware. Mirrors mocksEngine's
+  // src/assemblies/engines/mock/index.ts:55-57 — transforms a numeric seed into
+  // a seeded `random` function so callers can make stochastic mutations
+  // deterministic without hand-patching Math.random around the call site. Done
+  // on `params` (not `args`) so we stay clear of the function-count guard
+  // above, which is load-bearing for method dispatch.
+  if (typeof params.nonRandom === 'number') {
+    params.random = createSeededRandom(params.nonRandom);
+    delete params.nonRandom;
+  }
 
   const snapshot = params.rollbackOnError && makeDeepCopy(getTournamentRecords(), false, true);
 

--- a/src/assemblies/engines/sync/executionQueue.ts
+++ b/src/assemblies/engines/sync/executionQueue.ts
@@ -4,6 +4,7 @@ import { logMethodNotFound } from '@Assemblies/engines/parts/logMethodNotFound';
 import { executeFunction } from '@Assemblies/engines/parts/executeMethod';
 import { notifySubscribers } from '@Global/state/notifySubscribers';
 import { setState } from '@Assemblies/engines/parts/stateMethods';
+import { createSeededRandom } from '@Tools/prng';
 import { makeDeepCopy } from '@Tools/makeDeepCopy';
 
 // constants and types
@@ -27,6 +28,12 @@ export function executionQueue(engine: FactoryEngine, directives: Directives, ro
     const { method: methodName, pipe } = directive;
     const params = directive.params ? { ...directive.params } : {};
     if (!methods[methodName]) return logMethodNotFound({ methodName, start, params });
+
+    // nonRandom: <seed> middleware — see engineInvoke.ts for the rationale.
+    if (typeof params.nonRandom === 'number') {
+      params.random = createSeededRandom(params.nonRandom);
+      delete params.nonRandom;
+    }
 
     if (pipe) {
       const lastResult = results.at(-1);

--- a/src/tests/generators/mocks/seededRandom.test.ts
+++ b/src/tests/generators/mocks/seededRandom.test.ts
@@ -1,3 +1,4 @@
+import { engineInvoke } from '@Assemblies/engines/sync/engineInvoke';
 import { mocksEngine } from '@Assemblies/engines/mock';
 import { createSeededRandom } from '@Tools/prng';
 import { shuffleArray } from '@Tools/arrays';
@@ -125,4 +126,49 @@ test('without nonRandom, results vary between calls', () => {
 
   // With 16 random participants, it's astronomically unlikely to get the same order twice
   expect(names1).not.toEqual(names2);
+});
+
+// syncEngine wrapper middleware: a numeric `nonRandom` arriving on a method
+// call is transformed into `random: createSeededRandom(nonRandom)` before
+// dispatch — see src/assemblies/engines/sync/engineInvoke.ts. Mirrors the
+// long-standing mocksEngine middleware so stochastic mutations (e.g.
+// luckyDrawAdvancement) can be made deterministic without hand-patching
+// Math.random around the call site.
+test('engineInvoke transforms nonRandom into a seeded random function', () => {
+  let receivedParams: any;
+  const fakeEngine: any = {
+    echo: (params: any) => {
+      receivedParams = params;
+      return { success: true };
+    },
+  };
+
+  engineInvoke(fakeEngine, { method: 'echo', nonRandom: 42 });
+
+  expect(typeof receivedParams.random).toBe('function');
+  expect(receivedParams).not.toHaveProperty('nonRandom');
+
+  // Seeded output must match a freshly constructed seededRandom(42).
+  const reference = createSeededRandom(42);
+  const seededSample = Array.from({ length: 5 }, () => receivedParams.random());
+  const referenceSample = Array.from({ length: 5 }, () => reference());
+  expect(seededSample).toEqual(referenceSample);
+});
+
+test('engineInvoke leaves params untouched when nonRandom is absent or non-numeric', () => {
+  let receivedParams: any;
+  const fakeEngine: any = {
+    echo: (params: any) => {
+      receivedParams = params;
+      return { success: true };
+    },
+  };
+
+  engineInvoke(fakeEngine, { method: 'echo', participantId: 'p1' });
+  expect(receivedParams).not.toHaveProperty('random');
+  expect(receivedParams).not.toHaveProperty('nonRandom');
+
+  engineInvoke(fakeEngine, { method: 'echo', nonRandom: 'not-a-number' });
+  expect(receivedParams).not.toHaveProperty('random');
+  expect(receivedParams.nonRandom).toBe('not-a-number');
 });

--- a/src/tests/mutations/drawDefinitions/structures/customLuckyDraw.test.ts
+++ b/src/tests/mutations/drawDefinitions/structures/customLuckyDraw.test.ts
@@ -2,7 +2,6 @@ import { customLuckyDraw } from '@Generators/drawDefinitions/drawTypes/customLuc
 import { getRoundMatchUps } from '@Query/matchUps/getRoundMatchUps';
 import tournamentEngine from '@Engines/syncEngine';
 import mocksEngine from '@Assemblies/engines/mock';
-import { createSeededRandom } from '@Tools/prng';
 import { expect, test, describe } from 'vitest';
 
 import { LUCKY_DRAW } from '@Constants/drawDefinitionConstants';
@@ -59,21 +58,11 @@ describe('customLuckyDraw generator', () => {
 
 // The end-to-end LUCKY_DRAW tests exercise stochastic code paths in
 // `mocksEngine.generateTournamentRecord` (R1 outcomes) and
-// `luckyDrawAdvancement` (LL placement scoring tie-breaks).
-//
-// For mocksEngine: pass `nonRandom: <seed>` — the engine middleware at
-// src/assemblies/engines/mock/index.ts:55-57 wires
-// `random: createSeededRandom(seed)` through every internal Math.random
-// consumer.
-//
-// For luckyDrawAdvancement: the syncEngine wrapper rejects function-
-// typed params (`there must be only one arg with typeof function` in
-// src/assemblies/engines/sync/engineInvoke.ts:14-21 — the guard is
-// load-bearing because the wrapper uses the lone function in `args` to
-// dispatch the method). syncEngine has no analogous `nonRandom` middleware
-// today; patching Math.random for the single advancement call is the
-// minimum-blast-radius fix. Lifting the engine restriction (or adding the
-// nonRandom middleware to syncEngine) would be a cleaner long-term play.
+// `luckyDrawAdvancement` (LL placement scoring tie-breaks). Both honor
+// `nonRandom: <seed>`, which the engine wrappers transform into a seeded
+// `random` function before dispatch — see mocksEngine middleware at
+// src/assemblies/engines/mock/index.ts and the equivalent in
+// src/assemblies/engines/sync/engineInvoke.ts.
 describe('LUCKY_DRAW with explicit roundProfile end-to-end', () => {
   test('round-status reports requiredLuckyLoserCount derived from profile', () => {
     const roundProfile = [20, 12, 8, 4, 2, 1];
@@ -130,22 +119,13 @@ describe('LUCKY_DRAW with explicit roundProfile end-to-end', () => {
     const selectedLL = round1!.eligibleLosers!.slice(0, 4);
     const participantIds = selectedLL.map((l: any) => l.participantId);
 
-    // Patch Math.random only around the advancement call; restore
-    // immediately after. See the describe-block header for why this
-    // can't piggy-back on the nonRandom middleware.
-    const originalRandom = Math.random;
-    Math.random = createSeededRandom(2);
-    let result: any;
-    try {
-      result = tournamentEngine.luckyDrawAdvancement({
-        participantIds,
-        roundNumber: 1,
-        structureId,
-        drawId,
-      });
-    } finally {
-      Math.random = originalRandom;
-    }
+    let result: any = tournamentEngine.luckyDrawAdvancement({
+      participantIds,
+      roundNumber: 1,
+      structureId,
+      drawId,
+      nonRandom: 2,
+    });
     expect(result.success).toBe(true);
 
     // R2 should now have 12 matchUps fully populated (24 participants)


### PR DESCRIPTION
## Summary

Adds `nonRandom: <seed>` middleware to `syncEngine` so callers can make stochastic mutations deterministic the same way `mocksEngine` has long allowed. Closes the gap that forced the 2026-06-07 `customLuckyDraw.test.ts` deflake to combine `nonRandom: 1` on mocksEngine with a surgical `try/finally` Math.random patch around the syncEngine call.

The transform happens on `params` **after** the function-count guard in `engineInvoke.ts` — preserving the dispatcher's load-bearing "one function arg" invariant — and is mirrored into `executionQueue.ts` so queued mutations behave the same. Stochastic mutations that already accept a `random?: () => number` param thread the injected `random` through their internal `Math.random` fallback automatically; no per-mutation changes were needed.

- `factory/src/assemblies/engines/sync/engineInvoke.ts` — numeric `nonRandom` → `random: createSeededRandom(seed)` on params, with original key removed.
- `factory/src/assemblies/engines/sync/executionQueue.ts` — same transform per directive.
- `factory/src/tests/mutations/drawDefinitions/structures/customLuckyDraw.test.ts` — `try/finally Math.random` patch replaced with `nonRandom: 2` on the syncEngine call; describe-block header comment shortened.
- `factory/src/tests/generators/mocks/seededRandom.test.ts` — two regression tests using a fake-engine echo method (transform fires for numeric nonRandom; absent/non-numeric values pass through untouched).

## Test plan

- [x] `pnpm test --run` — 9869 passed, 3 skipped
- [x] `pnpm lint` — clean
- [x] `pnpm check-types` — clean
- [x] `pnpm build` — clean (Rollup + esbuild + .d.ts emission)
- [x] customLuckyDraw end-to-end test green without the Math.random patch
- [x] New regression tests catch the wrapper transform directly via a fake-engine echo