### PR TITLE
feat(schedule): auto-capture matchUp.schedule.scoredTime on first score

### DIFF
--- a/documentation/docs/governors/schedule-governor.md
+++ b/documentation/docs/governors/schedule-governor.md
@@ -1196,6 +1196,35 @@ engine.addMatchUpScheduleItems({
 
 ---
 
+## Auto-captured `scoredTime`
+
+`matchUp.schedule.scoredTime` is a first-class ISO-8601 timestamp that the engine
+captures **automatically** the first time a matchUp becomes scored — that is, when
+a score with value, a `winningSide`, or a completed `matchUpStatus` is applied via
+`setMatchUpStatus`. No caller action is required.
+
+Behavior:
+
+- **Captured once.** The first scored mutation stamps the timestamp; later score
+  corrections preserve the original value (it records when the result first
+  entered the system, not the latest edit).
+- **Cleared on removal.** If the score is removed (the matchUp is reset to
+  `TO_BE_PLAYED`), `scoredTime` is deleted, so a subsequent re-score gets a fresh
+  stamp.
+- **Proxy for completion time.** It is a lightweight stand-in for "when did this
+  match actually finish" when no explicit `END_TIME` time-item was recorded —
+  useful for analytics on tournament-director behaviour (how promptly results are
+  entered). An actual `endTime`, when present, supersedes it.
+- **No legacy mirror.** Like `calledAt`, `scoredTime` is a CODES-native schedule
+  attribute with no legacy time-item equivalent — it is always read from and
+  written to `matchUp.schedule.scoredTime`.
+
+This is engine-generated state, not an input: it is treated as read-only by
+consumers and reflects the engine's own capture, not a value supplied by the
+caller.
+
+---
+
 ## Related Documentation
 
 - **[Scheduling Overview](../concepts/scheduling-overview)** - Core scheduling concepts

--- a/src/mutate/matchUps/matchUpStatus/setMatchUpState.ts
+++ b/src/mutate/matchUps/matchUpStatus/setMatchUpState.ts
@@ -51,6 +51,7 @@ import {
   BYE,
   CANCELLED,
   COMPLETED,
+  completedMatchUpStatuses,
   DEFAULTED,
   DOUBLE_DEFAULT,
   DOUBLE_WALKOVER,
@@ -413,7 +414,30 @@ function resolveAndApplyOutcome({ params, isTeam, dualWinningSideChange, activeD
     result = { error: NO_VALID_ACTIONS };
   }
 
+  if (!result?.error) applyScoredTime({ matchUp });
+
   return decorateResult({ result, stack });
+}
+
+// Auto-capture matchUp.schedule.scoredTime the first time a matchUp becomes
+// "scored" (a score with value, a winningSide, or a completed status). Applied
+// at the convergence point so it covers every apply sub-path. Captured once —
+// later score corrections keep the original timestamp; cleared when the score
+// is removed so a subsequent re-score gets a fresh stamp. A lightweight proxy
+// for when the match actually finished (TD-behavior analytics) when no explicit
+// END_TIME timeItem is recorded; an actual endTime supersedes it at read time.
+function applyScoredTime({ matchUp }) {
+  const isScored =
+    !!matchUp.winningSide ||
+    checkScoreHasValue({ score: matchUp.score }) ||
+    (matchUp.matchUpStatus && completedMatchUpStatuses.includes(matchUp.matchUpStatus));
+
+  if (isScored) {
+    if (!matchUp.schedule) matchUp.schedule = {};
+    if (!matchUp.schedule.scoredTime) matchUp.schedule.scoredTime = new Date().toISOString();
+  } else if (matchUp.schedule?.scoredTime) {
+    delete matchUp.schedule.scoredTime;
+  }
 }
 
 function handleTeamAutoCalc({

--- a/src/tests/global/scoredTime.test.ts
+++ b/src/tests/global/scoredTime.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+
+// constants
+import { TO_BE_PLAYED } from '@Constants/matchUpStatusConstants';
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+
+function seedTournament() {
+  const result = mocksEngine.generateTournamentRecord({
+    inContext: true,
+    setState: true,
+    drawProfiles: [{ participantsCount: 8, drawSize: 8 }],
+  });
+  const drawId = result.drawIds[0];
+  const matchUpId = result.tournamentRecord.events[0].drawDefinitions[0].structures[0].matchUps[0].matchUpId;
+  return { drawId, matchUpId };
+}
+
+function outcome(scoreString = '6-3 6-4', winningSide = 1) {
+  return mocksEngine.generateOutcomeFromScoreString({ scoreString, winningSide }).outcome;
+}
+
+describe('schedule.scoredTime — auto-capture on score entry', () => {
+  it('stamps scoredTime as an ISO string the first time a matchUp is scored', () => {
+    const { drawId, matchUpId } = seedTournament();
+
+    const result: any = tournamentEngine.setMatchUpStatus({ drawId, matchUpId, outcome: outcome() });
+    expect(result.success).toEqual(true);
+
+    const { matchUp } = tournamentEngine.findMatchUp({ matchUpId });
+    expect(matchUp?.schedule?.scoredTime).toMatch(ISO_RE);
+  });
+
+  it('keeps the original scoredTime when a score is later corrected', () => {
+    const { drawId, matchUpId } = seedTournament();
+
+    tournamentEngine.setMatchUpStatus({ drawId, matchUpId, outcome: outcome('6-3 6-4', 1) });
+    const firstStamp = tournamentEngine.findMatchUp({ matchUpId }).matchUp?.schedule?.scoredTime;
+    expect(firstStamp).toMatch(ISO_RE);
+
+    // correction — same winner, different score
+    tournamentEngine.setMatchUpStatus({ drawId, matchUpId, outcome: outcome('6-3 7-6(3)', 1) });
+    const secondStamp = tournamentEngine.findMatchUp({ matchUpId }).matchUp?.schedule?.scoredTime;
+    expect(secondStamp).toEqual(firstStamp);
+  });
+
+  it('clears scoredTime when the score is removed (reset to TO_BE_PLAYED)', () => {
+    const { drawId, matchUpId } = seedTournament();
+
+    tournamentEngine.setMatchUpStatus({ drawId, matchUpId, outcome: outcome() });
+    expect(tournamentEngine.findMatchUp({ matchUpId }).matchUp?.schedule?.scoredTime).toMatch(ISO_RE);
+
+    tournamentEngine.setMatchUpStatus({
+      drawId,
+      matchUpId,
+      outcome: { matchUpStatus: TO_BE_PLAYED, winningSide: undefined, score: undefined },
+    });
+    expect(tournamentEngine.findMatchUp({ matchUpId }).matchUp?.schedule?.scoredTime).toBeUndefined();
+  });
+
+  it('does not stamp scoredTime on an unscored matchUp', () => {
+    const { matchUpId } = seedTournament();
+    const { matchUp } = tournamentEngine.findMatchUp({ matchUpId });
+    expect(matchUp?.schedule?.scoredTime).toBeUndefined();
+  });
+});

--- a/src/types/tournamentTypes.ts
+++ b/src/types/tournamentTypes.ts
@@ -377,6 +377,13 @@ export interface MatchUpSchedule {
   official?: any;
   scheduledDate?: string;
   scheduledTime?: string;
+  // CODES 5.0.0 first-class: ISO timestamp auto-captured the first time a
+  // matchUp receives a meaningful score/winningSide. A lightweight proxy for
+  // "when did this match actually finish" — useful for analytics on tournament
+  // director behavior when no explicit END_TIME timeItem was recorded.
+  // Cleared automatically when the score is removed; an actual endTime, when
+  // present, supersedes it. No legacy timeItem mirror.
+  scoredTime?: string;
   timeModifiers?: string[];
   venueId?: string;
   // derived/hydrated read-only fields (populated by getMatchUpScheduleDetails)


### PR DESCRIPTION
## What

Adds `matchUp.schedule.scoredTime` — an ISO-8601 timestamp the engine auto-captures the **first time a matchUp becomes scored** (a score with value, a `winningSide`, or a completed `matchUpStatus`).

## Why

A lightweight proxy for *when a match actually finished* when no explicit `END_TIME` time-item was recorded — useful for analytics on tournament-director behaviour (how promptly results are entered). An actual `endTime` supersedes it.

## Behavior

- **Captured once** — later score corrections preserve the original timestamp.
- **Cleared on removal** — resetting to `TO_BE_PLAYED` deletes it, so a re-score gets a fresh stamp.
- Applied at the `resolveAndApplyOutcome` convergence point in `setMatchUpState`, so it covers every apply sub-path (the common winning-side path bypasses `modifyMatchUpScore`).
- CODES-native schedule attribute, mirrors `calledAt` — no legacy timeItem mirror.
- Engine-generated; treated as read-only by consumers.

## Verification

- New focused test (`src/tests/global/scoredTime.test.ts`): stamp-on-score, idempotent-on-correction, clear-on-removal, no-stamp-when-unscored.
- Full suite green: 9884 passed. check-types, lint, and coverage thresholds all pass.
- Docs added to `schedule-governor.md`.