### PR TITLE
fix: harden getExitWinningSide against BYE positions + drop dead double-exit code

### DIFF
--- a/src/mutate/drawDefinitions/matchUpGovernor/getExitWinningSide.ts
+++ b/src/mutate/drawDefinitions/matchUpGovernor/getExitWinningSide.ts
@@ -8,6 +8,15 @@ export function getExitWinningSide({ inContextDrawMatchUps, drawPosition, matchU
     .sort((a, b) => a.roundPosition - b.roundPosition);
 
   const matchUp = inContextDrawMatchUps.find((matchUp) => matchUp.matchUpId === matchUpId);
+
+  // A BYE draw position can never be the winning side. Callers currently strip
+  // BYE positions before calling, so this guard is a no-op for them today — it
+  // exists so a future caller that forgets to filter cannot resurrect the
+  // "advance the empty/BYE side" bug class (see the progressExitStatus
+  // single-participant fix).
+  const targetSide = matchUp?.sides?.find((side) => side.drawPosition === drawPosition);
+  if (targetSide?.bye) return undefined;
+
   const feedRound = matchUp.feedRound;
 
   return feedRound

--- a/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
+++ b/src/mutate/drawDefinitions/positionGovernor/doubleExitAdvancement.ts
@@ -148,9 +148,7 @@ function handleLoserMatchUp({
   }
 
   const { feedRound, drawPositions, matchUpId } = loserMatchUp;
-  const walkoverWinningSide: number | undefined = feedRound
-    ? 2
-    : 2 - drawPositions.indexOf(loserTargetDrawPosition);
+  const walkoverWinningSide: number | undefined = feedRound ? 2 : 2 - drawPositions.indexOf(loserTargetDrawPosition);
   logAdvancement(stack, {
     color: 'cyan',
     decision: 'conditionallyAdvanceLoser',
@@ -549,18 +547,6 @@ function advanceFromTarget({
     });
   } else if (pairedPreviousMatchUpIsDoubleExit) {
     if (!noContextNextWinnerMatchUp) return { error: MISSING_MATCHUP };
-
-    if (nextWinnerMatchUpHasDrawPosition) {
-      const drawPosition = nextWinnerMatchUpDrawPositions[0];
-      const woWinningSide = getExitWinningSide({
-        matchUpId: targetMatchUp.matchUpId,
-        inContextDrawMatchUps,
-        drawPosition,
-      });
-      console.log('existing drawPosition is winningSide', {
-        walkoverWinningSide: woWinningSide,
-      });
-    }
 
     const nextMatchUpStatus = isExit(noContextNextWinnerMatchUp.matchUpStatus) ? EXIT : DOUBLE_EXIT;
 

--- a/src/tests/mutations/drawDefinitions/getExitWinningSide.test.ts
+++ b/src/tests/mutations/drawDefinitions/getExitWinningSide.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Unit coverage for the BYE guard added to getExitWinningSide. The guard is
+ * defensive (current callers strip BYE positions before calling), so it is
+ * exercised directly here to pin the "never resolve a BYE position as the
+ * winning side" contract.
+ */
+import { getExitWinningSide } from '@Mutate/drawDefinitions/matchUpGovernor/getExitWinningSide';
+import { expect, it, describe } from 'vitest';
+
+describe('getExitWinningSide — BYE guard', () => {
+  it('returns undefined when the target drawPosition is a BYE side', () => {
+    const matchUpId = 'm1';
+    const inContextDrawMatchUps: any[] = [
+      {
+        matchUpId,
+        feedRound: true, // would otherwise return 1; the BYE guard must win
+        drawPositions: [3, 4],
+        sides: [
+          { sideNumber: 1, drawPosition: 3, participantId: 'p3' },
+          { sideNumber: 2, drawPosition: 4, bye: true },
+        ],
+      },
+    ];
+    expect(getExitWinningSide({ inContextDrawMatchUps, drawPosition: 4, matchUpId })).toBeUndefined();
+  });
+
+  it('resolves a real (non-BYE) feed-round position to side 1 — guard is a no-op', () => {
+    const matchUpId = 'm1';
+    const inContextDrawMatchUps: any[] = [
+      {
+        matchUpId,
+        feedRound: true,
+        drawPositions: [3, 4],
+        sides: [
+          { sideNumber: 1, drawPosition: 3, participantId: 'p3' },
+          { sideNumber: 2, drawPosition: 4, participantId: 'p4' },
+        ],
+      },
+    ];
+    expect(getExitWinningSide({ inContextDrawMatchUps, drawPosition: 3, matchUpId })).toEqual(1);
+  });
+});

--- a/src/tests/mutations/drawDefinitions/setMatchUpStatus/fmlcExitPropagationBoundary.test.ts
+++ b/src/tests/mutations/drawDefinitions/setMatchUpStatus/fmlcExitPropagationBoundary.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Regression coverage for the exit-status propagation bug class that PR #4455
+ * fixed: when an exit (WALKOVER/DEFAULT/DOUBLE_WALKOVER) propagates into a
+ * downstream / consolation matchUp whose opponent draw position is a BYE, the
+ * engine must NOT award the win to the empty/BYE side.
+ *
+ * Rather than assert a specific feed topology, these tests pin the structural
+ * invariant across the whole draw after a variety of exit scenarios:
+ *   (a) no matchUp ever has a winningSide that points at a BYE side, and
+ *   (b) a matchUp converted to a double exit carries no winningSide.
+ */
+import mocksEngine from '@Assemblies/engines/mock';
+import tournamentEngine from '@Engines/syncEngine';
+import { expect, it, describe } from 'vitest';
+
+// constants
+import { FIRST_MATCH_LOSER_CONSOLATION } from '@Constants/drawDefinitionConstants';
+import { WALKOVER, DOUBLE_WALKOVER, DOUBLE_DEFAULT } from '@Constants/matchUpStatusConstants';
+
+const DOUBLE_EXITS = [DOUBLE_WALKOVER, DOUBLE_DEFAULT];
+
+/** The bug-class invariants, asserted over every matchUp in the tournament. */
+function assertExitInvariants(matchUps: any[]) {
+  for (const m of matchUps) {
+    if (m.winningSide) {
+      // (a) a winningSide must point at a side that holds a real participant —
+      // never a BYE / empty side (the PR #4455 failure mode).
+      const winner = m.sides?.find((s: any) => s.sideNumber === m.winningSide);
+      expect(winner?.bye, `matchUp ${m.matchUpId} (${m.matchUpStatus}) advanced a BYE side`).not.toEqual(true);
+      expect(winner?.participantId, `matchUp ${m.matchUpId} (${m.matchUpStatus}) advanced an empty side`).toBeTruthy();
+    }
+    // (b) a double-exit matchUp must have no winner.
+    if (DOUBLE_EXITS.includes(m.matchUpStatus)) {
+      expect(m.winningSide, `double-exit matchUp ${m.matchUpId} must have no winningSide`).toBeUndefined();
+    }
+  }
+}
+
+describe('FMLC / exit-status propagation never advances a BYE side', () => {
+  it('FMLC-8, adjacent first-round walkovers (exits feed consolation)', () => {
+    mocksEngine.generateTournamentRecord({
+      setState: true,
+      drawProfiles: [
+        {
+          drawId: 'fmlc-wos',
+          drawSize: 8,
+          drawType: FIRST_MATCH_LOSER_CONSOLATION,
+          idPrefix: 'w',
+          outcomes: [
+            { roundNumber: 1, roundPosition: 1, matchUpStatus: WALKOVER, winningSide: 1 },
+            { roundNumber: 1, roundPosition: 2, matchUpStatus: WALKOVER, winningSide: 1 },
+            { roundNumber: 1, roundPosition: 3, matchUpStatus: WALKOVER, winningSide: 2 },
+          ],
+        },
+      ],
+    });
+    assertExitInvariants(tournamentEngine.allTournamentMatchUps().matchUps);
+  });
+
+  it('FMLC-8 with byes, single walkover (lone exit-loser opposite a BYE in consolation)', () => {
+    mocksEngine.generateTournamentRecord({
+      setState: true,
+      drawProfiles: [
+        {
+          drawId: 'fmlc-bye',
+          drawSize: 8,
+          drawType: FIRST_MATCH_LOSER_CONSOLATION,
+          participantsCount: 6,
+          idPrefix: 'b',
+        },
+      ],
+    });
+    // walk over a couple of playable first-round matchUps so their losers feed consolation
+    const r1 = tournamentEngine
+      .allTournamentMatchUps()
+      .matchUps.filter((m) => m.stage === 'MAIN' && m.roundNumber === 1 && m.matchUpStatus === 'TO_BE_PLAYED');
+    for (const m of r1.slice(0, 2)) {
+      const result: any = tournamentEngine.setMatchUpStatus({
+        outcome: { matchUpStatus: WALKOVER, winningSide: 1 },
+        matchUpId: m.matchUpId,
+        drawId: 'fmlc-bye',
+      });
+      expect(result.success).toEqual(true);
+    }
+    assertExitInvariants(tournamentEngine.allTournamentMatchUps().matchUps);
+  });
+
+  it('SINGLE_ELIMINATION-16, sparse (9 players) with cascading double walkovers — pairedPreviousMatchUpIsDoubleExit branch', () => {
+    mocksEngine.generateTournamentRecord({
+      setState: true,
+      drawProfiles: [
+        {
+          drawId: 'se-sparse',
+          drawSize: 16,
+          participantsCount: 9,
+          idPrefix: 's',
+          outcomes: [
+            { roundNumber: 1, roundPosition: 1, matchUpStatus: DOUBLE_WALKOVER },
+            { roundNumber: 1, roundPosition: 2, matchUpStatus: DOUBLE_WALKOVER },
+          ],
+        },
+      ],
+    });
+    assertExitInvariants(tournamentEngine.allTournamentMatchUps().matchUps);
+  });
+
+  it('SINGLE_ELIMINATION-16, four adjacent double walkovers cascade (drives pairedPreviousMatchUpIsDoubleExit)', () => {
+    mocksEngine.generateTournamentRecord({
+      setState: true,
+      drawProfiles: [
+        {
+          drawId: 'se-cascade',
+          drawSize: 16,
+          idPrefix: 'c',
+          outcomes: [
+            { roundNumber: 1, roundPosition: 1, matchUpStatus: DOUBLE_WALKOVER },
+            { roundNumber: 1, roundPosition: 2, matchUpStatus: DOUBLE_WALKOVER },
+            { roundNumber: 1, roundPosition: 3, matchUpStatus: DOUBLE_WALKOVER },
+            { roundNumber: 1, roundPosition: 4, matchUpStatus: DOUBLE_WALKOVER },
+          ],
+        },
+      ],
+    });
+    const matchUps = tournamentEngine.allTournamentMatchUps().matchUps;
+    assertExitInvariants(matchUps);
+    // R2P1/R2P2 and R3P1 must convert to a double exit with no winner displaced.
+    const r3p1 = matchUps.find((m) => m.stage === 'MAIN' && m.roundNumber === 3 && m.roundPosition === 1);
+    expect(DOUBLE_EXITS).toContain(r3p1?.matchUpStatus);
+    expect(r3p1?.winningSide).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Follow-up to the exit-status / BYE-propagation **debate audit** (over the PR #4455 bug class). The audit found **zero new functional bugs** — the area is structurally sound — but surfaced one latent primitive and some dead code worth addressing. This is pure hardening + cleanup + coverage; **no behaviour change**.

## 1. Harden `getExitWinningSide`
The helper returned side 1 for any feed round and otherwise matched purely by `drawPosition` — **no BYE guard**. It's safe today only because every caller strips BYE positions (`.filter(Boolean)`) *before* calling — a property of the callers, not the helper. Added a defensive guard: a BYE-assigned `drawPosition` now resolves to `undefined` (a BYE can never be the winning side), so a future caller that forgets to filter can't resurrect the 'advance the empty/BYE side' bug. No-op for current callers.

## 2. Remove dead code in `doubleExitAdvancement`
Deleted a dead `getExitWinningSide` call whose result (`woWinningSide`) only fed a stray `console.log` — which **shipped to the published npm package** (the bundle sets no `drop_console`). The two live `getExitWinningSide` call sites are untouched.

## 3. Tests
- **`getExitWinningSide.test.ts`** — direct unit coverage of the new BYE guard (and the no-op path).
- **`fmlcExitPropagationBoundary.test.ts`** — topology-independent invariant coverage across FMLC and sparse single-elimination draws with propagated exits: **no matchUp ever advances a BYE/empty side**, and double-exit conversions carry **no `winningSide`** (pins the `pairedPreviousMatchUpIsDoubleExit` branch the cleanup touched).

## Verification
check-types ✅ · `verify:lint` (max-warnings 0) ✅ · full suite + coverage ✅ **9890 passed** (thresholds hold; the defensive guard line is covered by the unit test).

Related: PR #4455 (the original FMLC WO-vs-consolation-BYE fix).