### PR TITLE
feat(query): add getTournamentCalendarEntry deriver

### DIFF
--- a/documentation/docs/governors/query-governor.md
+++ b/documentation/docs/governors/query-governor.md
@@ -2043,6 +2043,19 @@ const { tournamentRecord } = engine.getTournament();
 
 ---
 
+## getTournamentCalendarEntry
+
+Derives the lightweight **calendar-list entry** for a tournament — the shape a tournaments list renders from without loading full tournament records. It wraps `getTournamentInfo` (so the `tournament` projection already carries `onlineResources`) and flattens the URL tournament image to `tournamentImageURL`. Non-URL images (e.g. court-SVG) are not flattened but remain available in `onlineResources` for the consumer to extract.
+
+Intended as the single source of truth for every calendar surface — a server persists it as a provider-calendar side-effect and a client can derive the identical entry from a local record, so remote and offline lists match. Pure: server-specific projections (e.g. an ownership stamp) are added by the caller.
+
+```js
+const { searchText, tournamentId, providerId, tournament } = engine.getTournamentCalendarEntry({ tournamentRecord });
+// tournament: { ...getTournamentInfo projection, startDate, endDate, tournamentName, tournamentImageURL }
+```
+
+---
+
 ## getTournamentInfo
 
 Returns tournament attributes. Used to attach details to publishing payload by `getEventData`.

--- a/src/assemblies/governors/tournamentGovernor/query.ts
+++ b/src/assemblies/governors/tournamentGovernor/query.ts
@@ -14,6 +14,7 @@ export { getTournamentStructures } from '@Query/structure/structureGetter';
 export { getTournamentActionableMatchUps } from '@Query/tournaments/getTournamentActionableMatchUps';
 export { getTournamentInconsistencies } from '@Query/tournaments/getTournamentInconsistencies';
 export { getTournamentCompleteness } from '@Query/tournaments/getTournamentCompleteness';
+export { getTournamentCalendarEntry } from '@Query/tournaments/getTournamentCalendarEntry';
 export { getTournamentInfo } from '@Query/tournaments/getTournamentInfo';
 export { analyzeTournament } from '@Query/tournaments/analyzeTournament';
 export { getTournamentPoints } from '@Query/scales/getTournamentPoints';

--- a/src/query/tournaments/getTournamentCalendarEntry.ts
+++ b/src/query/tournaments/getTournamentCalendarEntry.ts
@@ -1,0 +1,64 @@
+import { TOURNAMENT_IMAGE_RESOURCE_NAME } from '@Constants/tournamentConstants';
+import { getTournamentInfo } from '@Query/tournaments/getTournamentInfo';
+
+// types
+import { Tournament } from '@Types/tournamentTypes';
+
+export type TournamentCalendarEntry = {
+  searchText: string;
+  tournamentId?: string;
+  providerId?: string;
+  tournament: any;
+};
+
+/**
+ * Derive the lightweight calendar-list entry for a single tournament — the shape
+ * a tournaments list renders from WITHOUT loading full tournament records.
+ *
+ * Shared source of truth for every calendar surface: the server persists this as
+ * its provider-calendar side-effect and a local client (IndexedDB provider
+ * calendar) can derive the identical entry, so the list looks the same whether it
+ * is served remotely or offline. Keeping one deriver here is what prevents the two
+ * sides drifting (stale icons / missing images when the shapes diverge).
+ *
+ * `tournament` spreads the full `getTournamentInfo` projection, which already
+ * carries `onlineResources` (text-only links). Consumers extract both the URL
+ * image (`tournamentImageURL`, also flattened here) and the court-SVG image from
+ * those resources — no per-image field baking is required.
+ *
+ * Pure: reads only the record. Server-specific projections (e.g. an ownership
+ * `createdByUserId` stamp) are the caller's concern, not the factory's.
+ */
+export function getTournamentCalendarEntry({
+  tournamentRecord,
+}: {
+  tournamentRecord: Tournament;
+}): TournamentCalendarEntry {
+  const { tournamentName, tournamentId, startDate, endDate, parentOrganisation } = tournamentRecord;
+  const tournamentInfo = getTournamentInfo({ tournamentRecord })?.tournamentInfo ?? {};
+  const providerId = parentOrganisation?.organisationId;
+
+  const tournamentImageURL = tournamentRecord.onlineResources?.find(
+    (resource: any) =>
+      resource.resourceType === 'URL' &&
+      resource.resourceSubType === 'IMAGE' &&
+      resource.name === TOURNAMENT_IMAGE_RESOURCE_NAME,
+  )?.identifier;
+
+  // Normalize calendar-day fields to date-only ISO (guard against records that
+  // arrive without dates — `new Date(undefined)` would throw on toISOString).
+  const dateOnly = (value?: string) => (value ? new Date(value).toISOString().split('T')[0] : value);
+
+  return {
+    searchText: (tournamentName ?? '').toLowerCase(),
+    tournamentId,
+    providerId,
+    tournament: {
+      ...tournamentInfo,
+      startDate: dateOnly(startDate),
+      endDate: dateOnly(endDate),
+      tournamentImageURL,
+      tournamentName,
+    },
+  };
+}

--- a/src/tests/queries/tournaments/getTournamentCalendarEntry.test.ts
+++ b/src/tests/queries/tournaments/getTournamentCalendarEntry.test.ts
@@ -1,0 +1,66 @@
+import { getTournamentCalendarEntry } from '@Query/tournaments/getTournamentCalendarEntry';
+import { mocksEngine } from '@Assemblies/engines/mock';
+import { expect, test, describe } from 'vitest';
+
+describe('getTournamentCalendarEntry', () => {
+  const build = (onlineResources?: any[]) => {
+    const { tournamentRecord }: any = mocksEngine.generateTournamentRecord({
+      tournamentAttributes: { tournamentId: 'cal-1' },
+      drawProfiles: [{ drawSize: 4 }],
+    });
+    tournamentRecord.tournamentName = 'Spring Open';
+    tournamentRecord.startDate = '2026-05-10';
+    tournamentRecord.endDate = '2026-05-12';
+    tournamentRecord.parentOrganisation = { organisationId: 'prov-1' };
+    if (onlineResources) tournamentRecord.onlineResources = onlineResources;
+    return tournamentRecord;
+  };
+
+  test('derives the core lightweight entry fields', () => {
+    let result: any = getTournamentCalendarEntry({ tournamentRecord: build() });
+    expect(result.tournamentId).toBe('cal-1');
+    expect(result.providerId).toBe('prov-1');
+    expect(result.searchText).toBe('spring open');
+    expect(result.tournament.tournamentName).toBe('Spring Open');
+    expect(result.tournament.startDate).toBe('2026-05-10');
+    expect(result.tournament.endDate).toBe('2026-05-12');
+  });
+
+  test('flattens a URL tournamentImage into tournamentImageURL', () => {
+    const record = build([
+      { name: 'tournamentImage', resourceType: 'URL', resourceSubType: 'IMAGE', identifier: 'https://cdn/x.png' },
+    ]);
+    let result: any = getTournamentCalendarEntry({ tournamentRecord: record });
+    expect(result.tournament.tournamentImageURL).toBe('https://cdn/x.png');
+  });
+
+  test('ships onlineResources so a court-SVG (non-URL) image survives for downstream extraction', () => {
+    const courtSvg = {
+      name: 'tournamentImage',
+      resourceType: 'OTHER',
+      resourceSubType: 'COURT_SVG',
+      identifier: 'tennis',
+    };
+    let result: any = getTournamentCalendarEntry({ tournamentRecord: build([courtSvg]) });
+    // Not flattened to tournamentImageURL (it is not a URL) ...
+    expect(result.tournament.tournamentImageURL).toBeUndefined();
+    // ... but present in onlineResources so the card's court-SVG extractor works.
+    expect(result.tournament.onlineResources).toContainEqual(courtSvg);
+  });
+
+  test('omits server-only createdByUserId (stays a factory-pure entry)', () => {
+    const record = build();
+    record.extensions = [{ name: 'createdByUserId', value: 'user-123' }];
+    let result: any = getTournamentCalendarEntry({ tournamentRecord: record });
+    expect(result).not.toHaveProperty('createdByUserId');
+  });
+
+  test('guards missing dates instead of throwing on new Date(undefined)', () => {
+    const record = build();
+    delete record.startDate;
+    delete record.endDate;
+    let result: any = getTournamentCalendarEntry({ tournamentRecord: record });
+    expect(result.tournament.startDate).toBeUndefined();
+    expect(result.tournament.endDate).toBeUndefined();
+  });
+});

--- a/src/types/factoryEngineMethods.ts
+++ b/src/types/factoryEngineMethods.ts
@@ -357,6 +357,7 @@ export type FactoryEngineMethod =
   | 'getTimeItem'
   | 'getTournament'
   | 'getTournamentActionableMatchUps'
+  | 'getTournamentCalendarEntry'
   | 'getTournamentCompleteness'
   | 'getTournamentId'
   | 'getTournamentIds'
@@ -988,6 +989,7 @@ export const FACTORY_ENGINE_METHODS: readonly FactoryEngineMethod[] = [
   'getTimeItem',
   'getTournament',
   'getTournamentActionableMatchUps',
+  'getTournamentCalendarEntry',
   'getTournamentCompleteness',
   'getTournamentId',
   'getTournamentIds',

--- a/src/types/methodSignatures.ts
+++ b/src/types/methodSignatures.ts
@@ -185,6 +185,7 @@ import type { generateBookings } from '@Generators/scheduling/utils/generateBook
 import type { getApplicableAwardProfileLevels } from '@Query/scales/getApplicableAwardProfileLevels';
 import type { getLuckyDrawRoundStatus } from '@Query/drawDefinition/getLuckyDrawRoundStatus';
 import type { getMatchUpDailyLimitsUpdate } from '@Query/extensions/getMatchUpDailyLimitsUpdate';
+import type { getTournamentCalendarEntry } from '@Query/tournaments/getTournamentCalendarEntry';
 import type { getTournamentPublishStatus } from '@Query/tournaments/getTournamentPublishStatus';
 import type { initializeDraft } from '@Mutate/drawDefinitions/draft/initializeDraft';
 import type { predictMatchUpCompetitiveBands } from '@Query/matchUp/predictMatchUpCompetitiveBands';
@@ -880,6 +881,7 @@ export interface MethodSignatures {
   getTieFormat: EngineMethod<typeof getTieFormat>;
   getTimeItem: EngineMethod<typeof getTimeItem>;
   getTournamentActionableMatchUps: EngineMethod<typeof getTournamentActionableMatchUps>;
+  getTournamentCalendarEntry: EngineMethod<typeof getTournamentCalendarEntry>;
   getTournamentCompleteness: EngineMethod<typeof getTournamentCompleteness>;
   getTournamentIds: EngineMethod<typeof getTournamentIds>;
   getTournamentInconsistencies: EngineMethod<typeof getTournamentInconsistencies>;


### PR DESCRIPTION
Single pure source of truth for the lightweight tournaments-list calendar entry, so CFS (provider-calendar side-effect) and TMX-local (IndexedDB calendar) derive **identical** entries instead of drifting — the class that left list icons stale/missing.

- wraps `getTournamentInfo` (already ships `onlineResources`, so URL + court-SVG images are both derivable downstream — no field baking)
- flattens the URL image to `tournamentImageURL`; excludes server-only `createdByUserId` (caller stamps it)
- exposed via `queryGovernor` (codegen regenerated → 630 methods); Docusaurus doc + 5 tests

Next (separate, need factory published/linked): CFS `getCalendarEntry` → thin wrapper; TMX-local maintains `providers.calendar` on save + list reads it instead of full-loading.