### PR TITLE
fix(events): dispatch modify-event notice from standalone event-date setters

### DIFF
--- a/src/mutate/events/setEventDates.ts
+++ b/src/mutate/events/setEventDates.ts
@@ -45,6 +45,11 @@ export function setEventStartDate({ tournamentRecord, event, startDate }) {
 
   event.startDate = startDate;
 
+  // event dates are first-class + projected (read-model events row); the standalone
+  // setter must dispatch its own MODIFY_EVENT (setEventDates only fires it from the
+  // wrapper). Deduped by eventId, so the wrapper's redundant notice is harmless.
+  modifyEventNotice({ event, tournamentId: tournamentRecord?.tournamentId });
+
   return { ...SUCCESS };
 }
 
@@ -75,6 +80,10 @@ export function setEventEndDate(params) {
   }
 
   event.endDate = endDate;
+
+  // see setEventStartDate: dispatch MODIFY_EVENT from the standalone setter (deduped by eventId).
+  modifyEventNotice({ event, tournamentId: tournamentRecord?.tournamentId });
+
   return { ...SUCCESS };
 }
 

--- a/src/tests/mutations/notifications/noticeConformance/noticeConformanceScenarios.test.ts
+++ b/src/tests/mutations/notifications/noticeConformance/noticeConformanceScenarios.test.ts
@@ -231,6 +231,19 @@ const scenarios: Scenario[] = [
       tournamentEngine.setEventDates({ eventId: ctx.eventId, startDate: '2025-01-03', endDate: '2025-01-12' }),
   },
   {
+    // gap #7 CLOSED: the standalone setEventStartDate now dispatches MODIFY_EVENT
+    // (previously silent — only the setEventDates wrapper fired it).
+    name: 'setEventStartDate',
+    expectation: 'covered',
+    run: (ctx) => tournamentEngine.setEventStartDate({ eventId: ctx.eventId, startDate: '2025-01-04' }),
+  },
+  {
+    // gap #7 CLOSED: the standalone setEventEndDate now dispatches MODIFY_EVENT.
+    name: 'setEventEndDate',
+    expectation: 'covered',
+    run: (ctx) => tournamentEngine.setEventEndDate({ eventId: ctx.eventId, endDate: '2025-01-11' }),
+  },
+  {
     // C3 CLOSED: addEventEntries now dispatches MODIFY_EVENT_ENTRIES.
     name: 'addEventEntries (alternate)',
     expectation: 'covered',


### PR DESCRIPTION
Slice 2 (gap #7) of the read-model adversarial full-coverage challenge.

`setEventStartDate` / `setEventEndDate` mutate the event's first-class `startDate`/`endDate` and returned `SUCCESS` **without dispatching any notice** — only the `setEventDates` wrapper fired `modifyEventNotice`. A read-model built from the notice stream (the CQRS `query_events` projection) therefore left the event dates **stale** whenever a caller used the granular setters directly.

Each setter now dispatches `modifyEventNotice` (deduped by `eventId`, so the wrapper's own notice stays harmless). Adds notice-conformance scenarios for both setters. CFS already subscribes `MODIFY_EVENT` → `recordEvents`, so no CFS change is needed to consume this.

Tests: 149 targeted + 504 across events/publishing/notifications green; lint + check-types clean.