### PR TITLE
fix(read-model): max-of-levels embargo + roundLimit gating (disclosure fixes)

### DIFF
--- a/src/query/readModel/cast.ts
+++ b/src/query/readModel/cast.ts
@@ -78,6 +78,7 @@ export function cast(params?: CastArgs): { error?: ErrorType; success?: boolean;
       matchUp.drawId,
       matchUp.structureId,
       matchUp.stage,
+      matchUp.roundNumber,
     );
     const ctx: MatchUpRowContext = { tournamentId, providerId, published, embargo };
     const { matchUpRows, competitorRows } = matchUpRowSet(matchUp, ctx);

--- a/src/query/readModel/readModelPublish.ts
+++ b/src/query/readModel/readModelPublish.ts
@@ -7,13 +7,19 @@
  * boolean — a projection only refreshes on mutation, so a stored visibility flag
  * would go stale the instant an embargo lifts. Instead:
  *   - `published` = publish INTENT, resolved through the draw → stage → structure
- *     cascade (embargo-independent).
- *   - `embargo`   = the effective embargo release timestamp (ISO), with
- *     draw > stage > structure precedence (draw supersedes stage supersedes
- *     structure, per `DrawPublishingDetails`).
+ *     cascade (embargo-independent), further gated by a per-structure `roundLimit`
+ *     (rounds beyond the limit are hidden — a hard, time-independent hide).
+ *   - `embargo`   = the effective embargo release timestamp (ISO): the LATEST
+ *     (max) of every applicable level's embargo. `getEventData` hides a matchUp
+ *     while ANY of its applicable draw / stage / structure embargoes is active
+ *     (they are independent AND-gates), so it only becomes visible once the LAST
+ *     one lifts. A precedence "first-present" pick would let a lifted draw embargo
+ *     unmask a still-active structure embargo (premature disclosure).
  * Actual visibility is computed at READ time: `published AND (embargo IS NULL OR
  * embargo <= now())`.
  */
+
+import { isISODateString } from '@Tools/dateTime';
 
 export interface MatchUpPublishState {
   published: boolean;
@@ -43,12 +49,30 @@ function resolveIntent(drawDetail: any, structureId?: string, stage?: string): b
   return true;
 }
 
-// Effective embargo release, draw > stage > structure precedence.
+// Effective embargo release: the LATEST (max) of every applicable level's embargo.
+// A matchUp is hidden while ANY applicable draw/stage/structure embargo is active, so
+// it is visible only once the last one lifts — NOT the highest-precedence one (a lifted
+// draw embargo must not unmask a still-active structure embargo). Only ISO strings
+// constrain, matching `isEmbargoed`.
 function resolveEmbargo(drawDetail: any, structureId?: string, stage?: string): string | null {
-  const drawEmbargo = drawDetail.publishingDetail?.embargo;
-  const stageEmbargo = stage ? drawDetail.stageDetails?.[stage]?.embargo : undefined;
-  const structureEmbargo = structureId ? drawDetail.structureDetails?.[structureId]?.embargo : undefined;
-  return drawEmbargo ?? stageEmbargo ?? structureEmbargo ?? null;
+  const candidates = [
+    drawDetail.publishingDetail?.embargo,
+    stage ? drawDetail.stageDetails?.[stage]?.embargo : undefined,
+    structureId ? drawDetail.structureDetails?.[structureId]?.embargo : undefined,
+  ].filter((embargo): embargo is string => typeof embargo === 'string' && isISODateString(embargo));
+  if (!candidates.length) return null;
+  return candidates.reduce((latest, embargo) =>
+    new Date(embargo).getTime() > new Date(latest).getTime() ? embargo : latest,
+  );
+}
+
+// A per-structure `roundLimit` hides every round beyond the limit (getEventData drops
+// them from `roundMatchUps`); a hidden round is simply not published — a hard,
+// time-independent hide, distinct from an embargo release.
+function roundHidden(drawDetail: any, structureId?: string, roundNumber?: number): boolean {
+  if (structureId == null || roundNumber == null) return false;
+  const roundLimit = drawDetail.structureDetails?.[structureId]?.roundLimit;
+  return roundLimit != null && roundNumber > roundLimit;
 }
 
 export function resolveMatchUpPublishState(
@@ -56,6 +80,7 @@ export function resolveMatchUpPublishState(
   drawId?: string,
   structureId?: string,
   stage?: string,
+  roundNumber?: number,
 ): MatchUpPublishState {
   if (!status) return NOT_PUBLISHED; // no PUBLISH.STATUS → not published
   const { drawDetails } = status;
@@ -65,8 +90,9 @@ export function resolveMatchUpPublishState(
   const drawDetail = drawId ? drawDetails[drawId] : undefined;
   if (!drawDetail) return NOT_PUBLISHED; // draws enumerated, this one absent → not published
 
+  const published = resolveIntent(drawDetail, structureId, stage) && !roundHidden(drawDetail, structureId, roundNumber);
   return {
-    published: resolveIntent(drawDetail, structureId, stage),
+    published,
     embargo: resolveEmbargo(drawDetail, structureId, stage),
   };
 }

--- a/src/tests/queries/readModel/castPublishParity.test.ts
+++ b/src/tests/queries/readModel/castPublishParity.test.ts
@@ -1,0 +1,86 @@
+import tournamentEngine from '@Engines/syncEngine';
+import mocksEngine from '@Assemblies/engines/mock';
+import { cast } from '@Query/readModel/cast';
+import { expect, it, describe } from 'vitest';
+
+import { AD_HOC } from '@Constants/drawDefinitionConstants';
+import { SINGLES_EVENT } from '@Constants/eventConstants';
+
+// The read model's publish resolution must agree with getEventData (the oracle a
+// public consumer would otherwise re-query). These assert parity for the two
+// disclosure gaps the adversarial challenge confirmed.
+describe('cast() publish parity with getEventData', () => {
+  // #4 — a per-structure roundLimit hides rounds beyond the limit in getEventData;
+  // cast() must mark those match_ups published:false, not expose them.
+  it('roundLimit: cast published match_ups == getEventData visible matchUps (AD_HOC)', () => {
+    const {
+      tournamentRecord,
+      eventIds: [eventId],
+      drawIds: [drawId],
+    } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ eventType: SINGLES_EVENT, drawType: AD_HOC, automated: true, roundsCount: 3, drawSize: 20 }],
+      participantsProfile: { idPrefix: 'P' },
+    });
+    tournamentEngine.setState(tournamentRecord);
+    const structureId = tournamentEngine.getEvent({ drawId }).drawDefinition.structures[0].structureId;
+
+    tournamentEngine.publishEvent({
+      eventId,
+      removePriorValues: true,
+      drawDetails: { [drawId]: { structureDetails: { [structureId]: { roundLimit: 1, published: true } } } },
+    });
+
+    // getEventData oracle: the matchUpIds it actually exposes under usePublishState.
+    const { eventData } = tournamentEngine.getEventData({ eventId, usePublishState: true });
+    const structure = eventData.drawsData[0].structures.find((s: any) => s.structureId === structureId);
+    const visibleIds = new Set<string>(
+      Object.values(structure?.roundMatchUps ?? {}).flatMap((ms: any) => ms.map((m: any) => m.matchUpId)),
+    );
+
+    // cast(): the match_ups it marks published for the same structure.
+    const record = tournamentEngine.getTournament().tournamentRecord;
+    const rows: any = cast({ tournamentRecord: record }).rows;
+    const castPublishedIds = new Set<string>(
+      rows.match_ups.filter((r: any) => r.structure_id === structureId && r.published).map((r: any) => r.match_up_id),
+    );
+
+    expect([...castPublishedIds].sort()).toEqual([...visibleIds].sort());
+    // sanity: rounds beyond the limit exist but are NOT published by cast.
+    const beyondLimit = rows.match_ups.filter((r: any) => r.structure_id === structureId && (r.round_number ?? 0) > 1);
+    expect(beyondLimit.length).toBeGreaterThan(0);
+    expect(beyondLimit.every((r: any) => r.published === false)).toBe(true);
+  });
+
+  // #3 — multi-level embargo. A lifted (earlier) draw embargo must not unmask a
+  // later structure embargo; cast() stores the LATEST applicable release.
+  it('embargo: cast stores the max of draw + structure embargoes, not the higher-precedence one', () => {
+    const EARLY = '2020-01-01T00:00:00.000Z';
+    const LATE = '2999-01-01T00:00:00.000Z';
+    const {
+      tournamentRecord,
+      eventIds: [eventId],
+      drawIds: [drawId],
+    } = mocksEngine.generateTournamentRecord({ drawProfiles: [{ drawSize: 8, eventName: 'S' }] });
+    tournamentEngine.setState(tournamentRecord);
+    const structureId = tournamentEngine.getEvent({ drawId }).drawDefinition.structures[0].structureId;
+
+    tournamentEngine.publishEvent({
+      eventId,
+      removePriorValues: true,
+      drawDetails: {
+        [drawId]: {
+          publishingDetail: { published: true, embargo: EARLY },
+          structureDetails: { [structureId]: { published: true, embargo: LATE } },
+        },
+      },
+    });
+
+    const record = tournamentEngine.getTournament().tournamentRecord;
+    const rows: any = cast({ tournamentRecord: record }).rows;
+    const structureMatchUps = rows.match_ups.filter((r: any) => r.structure_id === structureId);
+    expect(structureMatchUps.length).toBeGreaterThan(0);
+    // the read gate (published AND embargo<=now) must stay hidden while the LATE
+    // structure embargo is active — so every row carries the LATE release, not EARLY.
+    expect(structureMatchUps.every((r: any) => r.embargo === LATE)).toBe(true);
+  });
+});

--- a/src/tests/queries/readModel/readModelPublish.test.ts
+++ b/src/tests/queries/readModel/readModelPublish.test.ts
@@ -2,6 +2,9 @@ import { resolveMatchUpPublishState } from '@Query/readModel/readModelPublish';
 import { expect, it, describe } from 'vitest';
 
 const FUTURE = '2999-01-01T00:00:00.000Z';
+const EARLY = '2020-01-01T00:00:00.000Z';
+const MID = '2050-01-01T00:00:00.000Z';
+const LATE = '2999-06-01T00:00:00.000Z';
 
 describe('resolveMatchUpPublishState', () => {
   it('is unpublished with no status', () => {
@@ -53,32 +56,72 @@ describe('resolveMatchUpPublishState', () => {
     expect(resolveMatchUpPublishState(status, 'd1', 's', 'QUALIFYING').published).toBe(false);
   });
 
-  it('resolves embargo with draw > stage > structure precedence', () => {
+  it('resolves the effective embargo as the LATEST (max) of applicable levels', () => {
     const structureOnly = {
-      drawDetails: { d1: { publishingDetail: { published: true }, structureDetails: { s1: { embargo: 'STRUCT' } } } },
+      drawDetails: { d1: { publishingDetail: { published: true }, structureDetails: { s1: { embargo: LATE } } } },
     };
-    expect(resolveMatchUpPublishState(structureOnly, 'd1', 's1', 'MAIN').embargo).toEqual('STRUCT');
+    expect(resolveMatchUpPublishState(structureOnly, 'd1', 's1', 'MAIN').embargo).toEqual(LATE);
 
-    const stageOverStructure = {
+    // a lifted/earlier DRAW embargo must NOT mask a later STRUCTURE embargo (the #3 fix):
+    // getEventData still hides while the structure embargo is active, so the read model
+    // must store the later release, not the higher-precedence one.
+    const earlyDrawLateStructure = {
       drawDetails: {
         d1: {
-          publishingDetail: { published: true },
-          stageDetails: { MAIN: { embargo: 'STAGE' } },
-          structureDetails: { s1: { embargo: 'STRUCT' } },
+          publishingDetail: { published: true, embargo: EARLY },
+          structureDetails: { s1: { embargo: LATE } },
         },
       },
     };
-    expect(resolveMatchUpPublishState(stageOverStructure, 'd1', 's1', 'MAIN').embargo).toEqual('STAGE');
+    expect(resolveMatchUpPublishState(earlyDrawLateStructure, 'd1', 's1', 'MAIN').embargo).toEqual(LATE);
 
-    const drawOverAll = {
+    // symmetric: a later DRAW embargo wins over an earlier structure embargo.
+    const lateDrawEarlyStructure = {
       drawDetails: {
         d1: {
-          publishingDetail: { published: true, embargo: 'DRAW' },
-          stageDetails: { MAIN: { embargo: 'STAGE' } },
-          structureDetails: { s1: { embargo: 'STRUCT' } },
+          publishingDetail: { published: true, embargo: LATE },
+          stageDetails: { MAIN: { embargo: MID } },
+          structureDetails: { s1: { embargo: EARLY } },
         },
       },
     };
-    expect(resolveMatchUpPublishState(drawOverAll, 'd1', 's1', 'MAIN').embargo).toEqual('DRAW');
+    expect(resolveMatchUpPublishState(lateDrawEarlyStructure, 'd1', 's1', 'MAIN').embargo).toEqual(LATE);
+
+    // the stage level participates in the max too.
+    const stageIsLatest = {
+      drawDetails: {
+        d1: {
+          publishingDetail: { published: true, embargo: EARLY },
+          stageDetails: { MAIN: { embargo: LATE } },
+          structureDetails: { s1: { embargo: MID } },
+        },
+      },
+    };
+    expect(resolveMatchUpPublishState(stageIsLatest, 'd1', 's1', 'MAIN').embargo).toEqual(LATE);
+
+    // non-ISO embargo values do not constrain (matches isEmbargoed) → null when none valid.
+    const nonIso = {
+      drawDetails: { d1: { publishingDetail: { published: true, embargo: 'not-a-date' } } },
+    };
+    expect(resolveMatchUpPublishState(nonIso, 'd1', 's1', 'MAIN').embargo).toEqual(null);
+  });
+
+  it('hides rounds beyond a per-structure roundLimit (published:false; the #4 fix)', () => {
+    const status = {
+      drawDetails: {
+        d1: { publishingDetail: { published: true }, structureDetails: { s1: { published: true, roundLimit: 1 } } },
+      },
+    };
+    // round 1 is within the limit → published; rounds beyond it are hidden.
+    expect(resolveMatchUpPublishState(status, 'd1', 's1', 'MAIN', 1).published).toBe(true);
+    expect(resolveMatchUpPublishState(status, 'd1', 's1', 'MAIN', 2).published).toBe(false);
+    expect(resolveMatchUpPublishState(status, 'd1', 's1', 'MAIN', 3).published).toBe(false);
+    // no roundNumber supplied → the roundLimit gate does not apply (back-compat).
+    expect(resolveMatchUpPublishState(status, 'd1', 's1', 'MAIN').published).toBe(true);
+    // no roundLimit set → all rounds published.
+    const noLimit = {
+      drawDetails: { d1: { publishingDetail: { published: true }, structureDetails: { s1: { published: true } } } },
+    };
+    expect(resolveMatchUpPublishState(noLimit, 'd1', 's1', 'MAIN', 9).published).toBe(true);
   });
 });


### PR DESCRIPTION
Slice 3 (gaps #3 + #4) of the read-model adversarial full-coverage challenge — two **disclosure** fixes where the projected query model exposed matchUps `getEventData` hides.

**#3 — multi-level embargo.** `resolveEmbargo` returned the highest-precedence *present* embargo (`draw ?? stage ?? structure`), but `getEventData` applies each level independently (AND). Empirically: draw embargo *past* + structure embargo *future* → `getEventData` returns **0 structures** (hidden) while the read model resolved `embargo = <past>` → visible-now. Fixed to resolve the effective release as the **latest (max)** of every applicable level's ISO embargo, so a lifted earlier embargo can't unmask a still-active later one.

**#4 — roundLimit.** A per-structure `roundLimit` hides rounds beyond the limit in `getEventData` (verified: AD_HOC `roundMatchUps` `['1','2','3']` → `['1']` at `roundLimit:1`), but `resolveMatchUpPublishState` never read it. It now accepts the matchUp `roundNumber` and marks rounds beyond the limit `published:false`. `cast()` threads `matchUp.roundNumber`.

Tests: unit coverage for both + **empirical parity tests** asserting `cast()`'s published/embargoed `match_ups` match `getEventData` (192 readModel+publishing tests green; lint + types clean).

**Coordination:** the paired CFS change (thread `roundNumber` in `buildProjectionDeltas` + a roundLimit conformance case) is coupled to this publishing — it lands with the CFS factory pin bump after this releases.