### PR TITLE
feat(read-model): project nested round-robin group structures (fix orphaned structure_id join)

### DIFF
--- a/src/query/readModel/cast.ts
+++ b/src/query/readModel/cast.ts
@@ -147,6 +147,28 @@ export function cast(params?: CastArgs): { error?: ErrorType; success?: boolean;
 // One row per draw, per top-level structure, and per participant-holding seed
 // assignment (walked together since they share the events → draws → structures
 // nesting). Extracted from cast() to keep its cognitive complexity within bounds.
+// Walk a structure list (and its nested round-robin group sub-structures)
+// depth-first, emitting a structures row + seed rows for each. `parentStructureId`
+// is the owning CONTAINER for a nested group (null at the top level) so a matchUp's
+// `structure_id` — which points at the GROUP, not the container — always resolves.
+function collectStructures(
+  structureList: any[],
+  baseCtx: { tournamentId: string; eventId: string; drawId: string; providerId: string | undefined },
+  parentStructureId: string | null,
+  structures: ReadModelRows['structures'],
+  seeds: ReadModelRows['seeds'],
+): void {
+  for (const structure of structureList ?? []) {
+    if (!structure?.structureId) continue;
+    structures.push(structureRow(structure, { ...baseCtx, parentStructureId }));
+    for (const assignment of structure.seedAssignments ?? []) {
+      if (!assignment?.participantId) continue;
+      seeds.push(seedRow(assignment, { ...baseCtx, structureId: structure.structureId }));
+    }
+    collectStructures(structure.structures, baseCtx, structure.structureId, structures, seeds);
+  }
+}
+
 function buildDrawEntityRows(
   tournamentRecord: any,
   tournamentId: string,
@@ -159,15 +181,8 @@ function buildDrawEntityRows(
     for (const draw of event.drawDefinitions ?? []) {
       if (!draw?.drawId) continue;
       draws.push(drawRow(draw, tournamentId, event.eventId, providerId));
-      for (const structure of draw.structures ?? []) {
-        if (!structure?.structureId) continue;
-        const sctx = { tournamentId, eventId: event.eventId, drawId: draw.drawId, providerId };
-        structures.push(structureRow(structure, sctx));
-        for (const assignment of structure.seedAssignments ?? []) {
-          if (!assignment?.participantId) continue;
-          seeds.push(seedRow(assignment, { ...sctx, structureId: structure.structureId }));
-        }
-      }
+      const baseCtx = { tournamentId, eventId: event.eventId, drawId: draw.drawId, providerId };
+      collectStructures(draw.structures, baseCtx, null, structures, seeds);
     }
   }
   return { draws, structures, seeds };

--- a/src/query/readModel/readModelRows.ts
+++ b/src/query/readModel/readModelRows.ts
@@ -120,12 +120,14 @@ export interface StructureRowContext {
   eventId: string | null;
   drawId: string;
   providerId: string | undefined;
+  // the owning CONTAINER structure when this is a nested round-robin group; omitted for top-level.
+  parentStructureId?: string | null;
 }
 
 /**
- * One row per TOP-LEVEL structure of a draw. Nested sub-structures (round-robin
- * groups) are not projected as their own rows — a known limitation shared with the
- * seeds table; playoff/qualifying structures are top-level siblings and ARE covered.
+ * One row per structure of a draw — top-level structures AND their nested
+ * round-robin group sub-structures (each carries `parent_structure_id` = its
+ * CONTAINER, so a matchUp's `structure_id` always resolves to a structures row).
  */
 export function structureRow(structure: any, ctx: StructureRowContext): ReadModelStructureRow {
   return {
@@ -140,6 +142,7 @@ export function structureRow(structure: any, ctx: StructureRowContext): ReadMode
     structure_type: structure?.structureType ?? null,
     structure_order: structure?.structureOrder ?? null,
     match_up_format: structure?.matchUpFormat ?? null,
+    parent_structure_id: ctx.parentStructureId ?? null,
   };
 }
 

--- a/src/tests/queries/readModel/cast.test.ts
+++ b/src/tests/queries/readModel/cast.test.ts
@@ -356,3 +356,29 @@ describe('cast — guard', () => {
     expect(result.error).toEqual(MISSING_TOURNAMENT_RECORD);
   });
 });
+
+describe('cast — round-robin nested group structures', () => {
+  it('projects each group sub-structure so every matchUp structure_id resolves (no orphans)', () => {
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, drawType: 'ROUND_ROBIN', eventName: 'RR' }],
+      nonRandom: 1,
+    });
+    const { rows } = cast({ tournamentRecord });
+    const structureIds = new Set(rows!.structures.map((s: any) => s.structure_id));
+    const matchUpStructureIds = [...new Set(rows!.match_ups.map((s: any) => s.structure_id))];
+
+    // every distinct matchUp structure_id resolves to a structures row (the join fix).
+    expect(matchUpStructureIds.length).toBeGreaterThan(0);
+    expect(matchUpStructureIds.every((id) => structureIds.has(id))).toBe(true);
+
+    // the container is projected AND at least two group ITEM rows point at it.
+    const container = rows!.structures.find((s: any) => s.structure_type === 'CONTAINER');
+    const groups = rows!.structures.filter((s: any) => s.parent_structure_id === container?.structure_id);
+    expect(container).toBeDefined();
+    expect(groups.length).toBeGreaterThanOrEqual(2);
+    // the group rows are exactly the structures the matchUps reference.
+    expect(groups.every((g: any) => matchUpStructureIds.includes(g.structure_id))).toBe(true);
+    // a top-level structure has a null parent.
+    expect(container!.parent_structure_id).toBeNull();
+  });
+});

--- a/src/tests/queries/readModel/readModelRows.test.ts
+++ b/src/tests/queries/readModel/readModelRows.test.ts
@@ -175,7 +175,17 @@ describe('structureRow', () => {
       structure_type: 'ITEM',
       structure_order: 1,
       match_up_format: 'SET3-S:6/TB7',
+      parent_structure_id: null,
     });
+  });
+
+  it('carries parent_structure_id for a nested round-robin group', () => {
+    const row = structureRow(
+      { structureId: 'g1', structureName: 'Group 1', structureType: 'ITEM' },
+      { ...sctx, parentStructureId: 'container-1' },
+    );
+    expect(row.structure_id).toBe('g1');
+    expect(row.parent_structure_id).toBe('container-1');
   });
 
   it('nulls optional fields on a bare structure', () => {

--- a/src/types/readModelTypes.ts
+++ b/src/types/readModelTypes.ts
@@ -110,6 +110,9 @@ export interface ReadModelStructureRow {
   structure_type: string | null;
   structure_order: number | null;
   match_up_format: string | null;
+  // the parent (CONTAINER) structure for a nested round-robin group; null for a
+  // top-level structure. Lets a consumer relate a group ITEM to its container.
+  parent_structure_id: string | null;
 }
 
 export interface ReadModelOrderOfPlayRow {


### PR DESCRIPTION
Slice from the read-model adversarial challenge (gap #2). `cast()` emitted only top-level structures, so for a ROUND_ROBIN draw only the CONTAINER got a row while 100% of group matchUps' `structure_id` pointed at an unprojected group — a broken `match_ups.structure_id` → `structures` join. Now walks nested structures, emitting a row per group with `parent_structure_id` (its container; null at top level). Nested group seedAssignments project too. Unit + empirical coverage (RR: no orphaned structure_id). Pairs with CFS + courthive-query PRs.