### PR TITLE
fix(read-model): legacy drawIds publish shape (#5) + shared scheduling-profile reader (#6)

### DIFF
--- a/src/query/readModel/cast.ts
+++ b/src/query/readModel/cast.ts
@@ -7,6 +7,7 @@ import {
   orderOfPlayRow,
   participantPublishRow,
   schedulingProfileRows,
+  resolveSchedulingProfile,
   seedRow,
   structureRow,
   tournamentRow,
@@ -15,8 +16,6 @@ import {
 } from './readModelRows';
 import { getTournamentPublishStatus } from '@Query/tournaments/getTournamentPublishStatus';
 import { getEventPublishStatus } from '@Query/event/getEventPublishStatus';
-import { findExtension } from '@Acquire/findExtension';
-import { SCHEDULING_PROFILE } from '@Constants/extensionConstants';
 import { allTournamentMatchUps } from '@Query/matchUps/getAllTournamentMatchUps';
 import { resolveMatchUpPublishState } from './readModelPublish';
 import { decorateResult } from '@Functions/global/decorateResult';
@@ -115,13 +114,9 @@ export function cast(params?: CastArgs): { error?: ErrorType; success?: boolean;
     ? [participantPublishRow(tournamentId, participants)]
     : [];
 
-  // scheduling PLAN (first-class `scheduling.profile` in NATIVE mode, else the
-  // SCHEDULING_PROFILE extension in LEGACY mode)
-  const profile =
-    (tournamentRecord as any).scheduling?.profile ??
-    findExtension({ element: tournamentRecord, name: SCHEDULING_PROFILE })?.extension?.value ??
-    [];
-  const scheduling_profile = schedulingProfileRows(tournamentId, profile);
+  // scheduling PLAN (first-class `scheduling.profile` NATIVE, else SCHEDULING_PROFILE
+  // extension LEGACY) — the shared resolver the CFS rebuild reads too.
+  const scheduling_profile = schedulingProfileRows(tournamentId, resolveSchedulingProfile(tournamentRecord));
 
   return {
     ...SUCCESS,

--- a/src/query/readModel/index.ts
+++ b/src/query/readModel/index.ts
@@ -20,6 +20,7 @@ export {
   courtRow,
   orderOfPlayRow,
   schedulingProfileRows,
+  resolveSchedulingProfile,
   participantPublishRow,
   entryRows,
   matchUpRowSet,

--- a/src/query/readModel/readModelPublish.ts
+++ b/src/query/readModel/readModelPublish.ts
@@ -84,7 +84,14 @@ export function resolveMatchUpPublishState(
 ): MatchUpPublishState {
   if (!status) return NOT_PUBLISHED; // no PUBLISH.STATUS → not published
   const { drawDetails } = status;
-  if (!drawDetails) return { published: !!status.published, embargo: null }; // legacy event-level flag
+  if (!drawDetails) {
+    // legacy v1 shape: a top-level `drawIds` array lists the published draws (no
+    // per-draw detail). Mirror getDrawIsPublished's drawIds branch — a listed draw
+    // is published, an unlisted one is not (so a stray event-level `published:true`
+    // no longer over-discloses unlisted draws).
+    if (Array.isArray(status.drawIds)) return { published: !!drawId && status.drawIds.includes(drawId), embargo: null };
+    return { published: !!status.published, embargo: null }; // legacy event-level flag
+  }
   if (!Object.keys(drawDetails).length) return { published: true, embargo: null }; // empty drawDetails → all published
 
   const drawDetail = drawId ? drawDetails[drawId] : undefined;

--- a/src/query/readModel/readModelRows.ts
+++ b/src/query/readModel/readModelRows.ts
@@ -1,5 +1,7 @@
 import { getTournamentPublishStatus } from '@Query/tournaments/getTournamentPublishStatus';
+import { SCHEDULING_PROFILE } from '@Constants/extensionConstants';
 import { LINK_UNRESOLVED, resolvePersonLink } from './personRule';
+import { findExtension } from '@Acquire/findExtension';
 
 // types
 import {
@@ -161,6 +163,19 @@ export function orderOfPlayRow(tournamentId: string, orderOfPlay: any): ReadMode
     event_ids: orderOfPlay?.eventIds ?? null,
     embargo: orderOfPlay?.embargo ?? null,
   };
+}
+
+/**
+ * The stored scheduling PLAN for a tournament: first-class `scheduling.profile`
+ * (NATIVE writeMode), else the `SCHEDULING_PROFILE` extension (LEGACY/imported
+ * records). The single source both `cast()` and the CFS rebuild read, so a LEGACY
+ * record projects identically either way (the rebuild used to read NATIVE only and
+ * silently wiped the table for extension-backed profiles).
+ */
+export function resolveSchedulingProfile(record: any): any[] {
+  return (
+    record?.scheduling?.profile ?? findExtension({ element: record, name: SCHEDULING_PROFILE })?.extension?.value ?? []
+  );
 }
 
 /**

--- a/src/tests/queries/readModel/readModelPublish.test.ts
+++ b/src/tests/queries/readModel/readModelPublish.test.ts
@@ -16,6 +16,14 @@ describe('resolveMatchUpPublishState', () => {
     expect(resolveMatchUpPublishState({ published: false }, 'd1')).toEqual({ published: false, embargo: null });
   });
 
+  it('resolves the legacy v1 drawIds-array shape per-draw (mirrors getDrawIsPublished)', () => {
+    // a listed draw is published; an unlisted one is not.
+    expect(resolveMatchUpPublishState({ drawIds: ['d1'] }, 'd1')).toEqual({ published: true, embargo: null });
+    expect(resolveMatchUpPublishState({ drawIds: ['d1'] }, 'd2')).toEqual({ published: false, embargo: null });
+    // a stray event-level published:true must NOT over-disclose an unlisted draw.
+    expect(resolveMatchUpPublishState({ published: true, drawIds: ['d1'] }, 'd2').published).toBe(false);
+  });
+
   it('treats empty drawDetails as all-published', () => {
     expect(resolveMatchUpPublishState({ drawDetails: {} }, 'd1')).toEqual({ published: true, embargo: null });
   });


### PR DESCRIPTION
Final two gaps from the read-model adversarial challenge.

**#5** — `resolveMatchUpPublishState`'s no-drawDetails branch ignored the legacy v1 top-level `drawIds` array (listing published draws), returning the event-level `published` flag: a listed draw resolved `published:false` (under-disclosure) and a stray `published:true` marked every draw published (over-disclosure of unlisted draws). Now mirrors `getDrawIsPublished` — published iff the draw is in `drawIds`. Unit coverage added.

**#6** — extract the native-first-with-legacy-extension scheduling read (`scheduling.profile ?? SCHEDULING_PROFILE extension`) into a shared exported `resolveSchedulingProfile(record)`, so `cast()` and the CFS rebuild read one source (the rebuild read NATIVE only and emptied the table for extension-backed LEGACY records). `cast()` refactored to use it (behavior unchanged).

74 readModel tests green; coverage gate passes; lint + types clean. Pairs with the CFS rebuild PR.