### PR TITLE
fix(read-model): match_up_format + schedule_embargo columns, derive scheduled_date (#9/#10/#11)

### DIFF
--- a/src/query/readModel/cast.ts
+++ b/src/query/readModel/cast.ts
@@ -72,14 +72,14 @@ export function cast(params?: CastArgs): { error?: ErrorType; success?: boolean;
     // parent in `matchUpRowSet`; processing it here too would double-project it.
     if (matchUp.collectionId) continue;
     const status = matchUp.eventId ? publishStatusByEventId.get(matchUp.eventId) : undefined;
-    const { published, embargo } = resolveMatchUpPublishState(
+    const { published, embargo, scheduleEmbargo } = resolveMatchUpPublishState(
       status,
       matchUp.drawId,
       matchUp.structureId,
       matchUp.stage,
       matchUp.roundNumber,
     );
-    const ctx: MatchUpRowContext = { tournamentId, providerId, published, embargo };
+    const ctx: MatchUpRowContext = { tournamentId, providerId, published, embargo, scheduleEmbargo };
     const { matchUpRows, competitorRows } = matchUpRowSet(matchUp, ctx);
     match_ups.push(...matchUpRows);
     match_up_competitors.push(...competitorRows);

--- a/src/query/readModel/readModelPublish.ts
+++ b/src/query/readModel/readModelPublish.ts
@@ -24,9 +24,13 @@ import { isISODateString } from '@Tools/dateTime';
 export interface MatchUpPublishState {
   published: boolean;
   embargo: string | null;
+  // round-level (scheduledRounds) embargo release: while active, getEventData redacts
+  // the round's placement (venue/court/time) though the matchUp itself stays visible.
+  // Stored so a consumer gates venue_id/court_id at read time (like `embargo`); NULL = none.
+  scheduleEmbargo: string | null;
 }
 
-const NOT_PUBLISHED: MatchUpPublishState = { published: false, embargo: null };
+const NOT_PUBLISHED: MatchUpPublishState = { published: false, embargo: null, scheduleEmbargo: null };
 
 function keyed(obj?: Record<string, any>): boolean {
   return !!obj && Object.keys(obj).length > 0;
@@ -75,6 +79,14 @@ function roundHidden(drawDetail: any, structureId?: string, roundNumber?: number
   return roundLimit != null && roundNumber > roundLimit;
 }
 
+// The round-level scheduledRounds embargo (structure → round), the finer gate that
+// redacts a round's placement while the matchUp stays visible. Only ISO strings constrain.
+function resolveScheduleEmbargo(drawDetail: any, structureId?: string, roundNumber?: number): string | null {
+  if (structureId == null || roundNumber == null) return null;
+  const embargo = drawDetail.structureDetails?.[structureId]?.scheduledRounds?.[roundNumber]?.embargo;
+  return typeof embargo === 'string' && isISODateString(embargo) ? embargo : null;
+}
+
 export function resolveMatchUpPublishState(
   status: any,
   drawId?: string,
@@ -89,10 +101,11 @@ export function resolveMatchUpPublishState(
     // per-draw detail). Mirror getDrawIsPublished's drawIds branch — a listed draw
     // is published, an unlisted one is not (so a stray event-level `published:true`
     // no longer over-discloses unlisted draws).
-    if (Array.isArray(status.drawIds)) return { published: !!drawId && status.drawIds.includes(drawId), embargo: null };
-    return { published: !!status.published, embargo: null }; // legacy event-level flag
+    if (Array.isArray(status.drawIds))
+      return { published: !!drawId && status.drawIds.includes(drawId), embargo: null, scheduleEmbargo: null };
+    return { published: !!status.published, embargo: null, scheduleEmbargo: null }; // legacy event-level flag
   }
-  if (!Object.keys(drawDetails).length) return { published: true, embargo: null }; // empty drawDetails → all published
+  if (!Object.keys(drawDetails).length) return { published: true, embargo: null, scheduleEmbargo: null }; // empty → all published
 
   const drawDetail = drawId ? drawDetails[drawId] : undefined;
   if (!drawDetail) return NOT_PUBLISHED; // draws enumerated, this one absent → not published
@@ -101,5 +114,6 @@ export function resolveMatchUpPublishState(
   return {
     published,
     embargo: resolveEmbargo(drawDetail, structureId, stage),
+    scheduleEmbargo: resolveScheduleEmbargo(drawDetail, structureId, roundNumber),
   };
 }

--- a/src/query/readModel/readModelRows.ts
+++ b/src/query/readModel/readModelRows.ts
@@ -31,6 +31,7 @@ export interface MatchUpRowContext {
   providerId: string | undefined;
   published: boolean;
   embargo: string | null;
+  scheduleEmbargo?: string | null;
 }
 
 export interface MatchUpRowSet {
@@ -306,7 +307,15 @@ function winnerPerspectiveScore(matchUp: any): string | null {
 }
 
 function matchUpScheduledDate(matchUp: any): string | null {
-  return matchUp?.schedule?.scheduledDate ?? matchUp?.scheduledDate ?? null;
+  const schedule = matchUp?.schedule;
+  if (schedule?.scheduledDate) return schedule.scheduledDate;
+  // A scheduledTime stored as a full ISO datetime carries the date; the inContext
+  // flatten derives scheduledDate from it. Mirror that so the slim MODIFY_MATCHUP
+  // result row (which sees the raw matchUp) does not clobber a flattened
+  // scheduled_date to null for a scheduledTime-only matchUp.
+  const isoDate = /^(\d{4}-\d{2}-\d{2})T/.exec(schedule?.scheduledTime ?? '');
+  if (isoDate) return isoDate[1];
+  return matchUp?.scheduledDate ?? null;
 }
 
 function matchUpVenueId(matchUp: any): string | null {
@@ -342,9 +351,13 @@ function matchUpRow(
     winning_side: matchUp?.winningSide ?? null,
     score_string: winnerPerspectiveScore(matchUp),
     tie_value: tieValue,
+    // a per-matchUp scoring-format override (e.g. a best-of-5 final in a best-of-3
+    // draw); null falls back to the draw/structure default at read time.
+    match_up_format: matchUp?.matchUpFormat ?? null,
     scheduled_date: matchUpScheduledDate(matchUp),
     published: ctx.published,
     embargo: ctx.embargo,
+    schedule_embargo: ctx.scheduleEmbargo ?? null,
   };
 }
 

--- a/src/tests/queries/readModel/castPublishParity.test.ts
+++ b/src/tests/queries/readModel/castPublishParity.test.ts
@@ -83,4 +83,76 @@ describe('cast() publish parity with getEventData', () => {
     // structure embargo is active — so every row carries the LATE release, not EARLY.
     expect(structureMatchUps.every((r: any) => r.embargo === LATE)).toBe(true);
   });
+
+  // #9 — a scheduledRounds embargo redacts a round's placement in getEventData while
+  // the matchUp stays visible. cast() keeps the raw venue_id (usePublishState:false)
+  // but now carries schedule_embargo so a consumer can gate venue_id/court_id at read time.
+  it('scheduledRounds embargo: cast carries schedule_embargo for the embargoed round', () => {
+    const LATE = '2099-01-01T00:00:00.000Z';
+    const {
+      tournamentRecord,
+      eventIds: [eventId],
+      drawIds: [drawId],
+    } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, eventName: 'S' }],
+      venueProfiles: [{ venueId: 'v1', venueName: 'Club', courtsCount: 4, idPrefix: 'c' }],
+      startDate: '2025-01-05',
+      endDate: '2025-01-08',
+    });
+    tournamentEngine.setState(tournamentRecord);
+    const structureId = tournamentEngine.getEvent({ drawId }).drawDefinition.structures[0].structureId;
+    tournamentEngine.publishEvent({
+      eventId,
+      removePriorValues: true,
+      drawDetails: {
+        [drawId]: {
+          publishingDetail: { published: true },
+          structureDetails: { [structureId]: { published: true, scheduledRounds: { 2: { embargo: LATE } } } },
+        },
+      },
+    });
+    const record = tournamentEngine.getTournament().tournamentRecord;
+    const rows: any = cast({ tournamentRecord: record }).rows;
+    const round2 = rows.match_ups.filter((r: any) => r.structure_id === structureId && r.round_number === 2);
+    const round1 = rows.match_ups.filter((r: any) => r.structure_id === structureId && r.round_number === 1);
+    expect(round2.length).toBeGreaterThan(0);
+    expect(round2.every((r: any) => r.schedule_embargo === LATE)).toBe(true); // gated round carries the release
+    expect(round1.every((r: any) => r.schedule_embargo === null)).toBe(true); // other rounds unaffected
+  });
+
+  // #10 — a matchUp scheduled with scheduledTime ONLY (a full ISO datetime, no
+  // scheduledDate) must project a derived scheduled_date, not null (so the slim
+  // MODIFY_MATCHUP result row cannot clobber it).
+  it('scheduledTime-only matchUp: cast derives scheduled_date (not null)', () => {
+    const {
+      tournamentRecord,
+      drawIds: [drawId],
+    } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 4, eventName: 'S' }],
+      startDate: '2025-01-05',
+      endDate: '2025-01-07',
+    });
+    tournamentEngine.setState(tournamentRecord);
+    const mu = tournamentEngine.allTournamentMatchUps().matchUps.find((m: any) => m.roundNumber === 1);
+    tournamentEngine.addMatchUpScheduledTime({ drawId, matchUpId: mu.matchUpId, scheduledTime: '2025-01-06T14:00' });
+    const record = tournamentEngine.getTournament().tournamentRecord;
+    const rows: any = cast({ tournamentRecord: record }).rows;
+    const row = rows.match_ups.find((r: any) => r.match_up_id === mu.matchUpId);
+    expect(row.scheduled_date).toBe('2025-01-06');
+  });
+
+  // #11 — a per-matchUp matchUpFormat override is projected to match_up_format.
+  it('per-matchUp matchUpFormat override is projected', () => {
+    const {
+      tournamentRecord,
+      drawIds: [drawId],
+    } = mocksEngine.generateTournamentRecord({ drawProfiles: [{ drawSize: 4, eventName: 'S' }] });
+    tournamentEngine.setState(tournamentRecord);
+    const mu = tournamentEngine.allTournamentMatchUps().matchUps.find((m: any) => m.roundNumber === 1);
+    tournamentEngine.setMatchUpFormat({ drawId, matchUpId: mu.matchUpId, matchUpFormat: 'SET5-S:6/TB7' });
+    const record = tournamentEngine.getTournament().tournamentRecord;
+    const rows: any = cast({ tournamentRecord: record }).rows;
+    const row = rows.match_ups.find((r: any) => r.match_up_id === mu.matchUpId);
+    expect(row.match_up_format).toBe('SET5-S:6/TB7');
+  });
 });

--- a/src/tests/queries/readModel/readModelPublish.test.ts
+++ b/src/tests/queries/readModel/readModelPublish.test.ts
@@ -8,34 +8,66 @@ const LATE = '2999-06-01T00:00:00.000Z';
 
 describe('resolveMatchUpPublishState', () => {
   it('is unpublished with no status', () => {
-    expect(resolveMatchUpPublishState(undefined, 'd1')).toEqual({ published: false, embargo: null });
+    expect(resolveMatchUpPublishState(undefined, 'd1')).toEqual({
+      published: false,
+      embargo: null,
+      scheduleEmbargo: null,
+    });
   });
 
   it('honors a legacy event-level published flag when drawDetails is absent', () => {
-    expect(resolveMatchUpPublishState({ published: true }, 'd1')).toEqual({ published: true, embargo: null });
-    expect(resolveMatchUpPublishState({ published: false }, 'd1')).toEqual({ published: false, embargo: null });
+    expect(resolveMatchUpPublishState({ published: true }, 'd1')).toEqual({
+      published: true,
+      embargo: null,
+      scheduleEmbargo: null,
+    });
+    expect(resolveMatchUpPublishState({ published: false }, 'd1')).toEqual({
+      published: false,
+      embargo: null,
+      scheduleEmbargo: null,
+    });
   });
 
   it('resolves the legacy v1 drawIds-array shape per-draw (mirrors getDrawIsPublished)', () => {
     // a listed draw is published; an unlisted one is not.
-    expect(resolveMatchUpPublishState({ drawIds: ['d1'] }, 'd1')).toEqual({ published: true, embargo: null });
-    expect(resolveMatchUpPublishState({ drawIds: ['d1'] }, 'd2')).toEqual({ published: false, embargo: null });
+    expect(resolveMatchUpPublishState({ drawIds: ['d1'] }, 'd1')).toEqual({
+      published: true,
+      embargo: null,
+      scheduleEmbargo: null,
+    });
+    expect(resolveMatchUpPublishState({ drawIds: ['d1'] }, 'd2')).toEqual({
+      published: false,
+      embargo: null,
+      scheduleEmbargo: null,
+    });
     // a stray event-level published:true must NOT over-disclose an unlisted draw.
     expect(resolveMatchUpPublishState({ published: true, drawIds: ['d1'] }, 'd2').published).toBe(false);
   });
 
   it('treats empty drawDetails as all-published', () => {
-    expect(resolveMatchUpPublishState({ drawDetails: {} }, 'd1')).toEqual({ published: true, embargo: null });
+    expect(resolveMatchUpPublishState({ drawDetails: {} }, 'd1')).toEqual({
+      published: true,
+      embargo: null,
+      scheduleEmbargo: null,
+    });
   });
 
   it('is unpublished when the draw is enumerated but absent', () => {
     const status = { drawDetails: { other: { publishingDetail: { published: true } } } };
-    expect(resolveMatchUpPublishState(status, 'd1')).toEqual({ published: false, embargo: null });
+    expect(resolveMatchUpPublishState(status, 'd1')).toEqual({
+      published: false,
+      embargo: null,
+      scheduleEmbargo: null,
+    });
   });
 
   it('publishes a listed draw and carries a draw-level embargo (intent stays true under embargo)', () => {
     const status = { drawDetails: { d1: { publishingDetail: { published: true, embargo: FUTURE } } } };
-    expect(resolveMatchUpPublishState(status, 'd1', 's1', 'MAIN')).toEqual({ published: true, embargo: FUTURE });
+    expect(resolveMatchUpPublishState(status, 'd1', 's1', 'MAIN')).toEqual({
+      published: true,
+      embargo: FUTURE,
+      scheduleEmbargo: null,
+    });
   });
 
   it('applies the structure gate: enumerated structures publish only the listed ones', () => {
@@ -112,6 +144,22 @@ describe('resolveMatchUpPublishState', () => {
       drawDetails: { d1: { publishingDetail: { published: true, embargo: 'not-a-date' } } },
     };
     expect(resolveMatchUpPublishState(nonIso, 'd1', 's1', 'MAIN').embargo).toEqual(null);
+  });
+
+  it('resolves the round-level scheduledRounds embargo into scheduleEmbargo (#9)', () => {
+    const status = {
+      drawDetails: {
+        d1: {
+          publishingDetail: { published: true },
+          structureDetails: { s1: { published: true, scheduledRounds: { 2: { embargo: LATE } } } },
+        },
+      },
+    };
+    // the embargoed round carries scheduleEmbargo; other rounds do not.
+    expect(resolveMatchUpPublishState(status, 'd1', 's1', 'MAIN', 2).scheduleEmbargo).toBe(LATE);
+    expect(resolveMatchUpPublishState(status, 'd1', 's1', 'MAIN', 1).scheduleEmbargo).toBeNull();
+    // the matchUp itself stays published (whole-matchUp visibility is unaffected).
+    expect(resolveMatchUpPublishState(status, 'd1', 's1', 'MAIN', 2).published).toBe(true);
   });
 
   it('hides rounds beyond a per-structure roundLimit (published:false; the #4 fix)', () => {

--- a/src/types/readModelTypes.ts
+++ b/src/types/readModelTypes.ts
@@ -46,9 +46,11 @@ export interface ReadModelMatchUpRow {
   winning_side: number | null;
   score_string: string | null; // winner-perspective
   tie_value: number | null; // rubber weight from the tieFormat (RUBBER rows); NULL otherwise
+  match_up_format: string | null; // per-matchUp scoring-format override; NULL = draw/structure default
   scheduled_date: string | null;
   published: boolean; // publish INTENT (embargo-independent) — resolved through the structure/stage/draw cascade
   embargo: string | null; // effective embargo release (ISO), draw>stage>structure precedence; NULL when none
+  schedule_embargo: string | null; // round-level (scheduledRounds) embargo release; gate venue_id/court_id on it at read time
 }
 
 export interface ReadModelCompetitorRow {


### PR DESCRIPTION
The three PLAUSIBLE findings from the adversarial challenge, all empirically confirmed vs getEventData:

**#11 match_up_format** — a per-matchUp scoring-format override was unprojected/unrecoverable. New `match_up_format` column (null = draw/structure default).

**#9 schedule_embargo** — a `scheduledRounds` round-level embargo redacts a round's placement (venue/court/time) in getEventData while the matchUp stays visible, but cast() exposed the raw `venue_id` with no gate (empirically: getEventData returns the matchUp with `venueId:null`, cast kept `v1`). New `schedule_embargo` column (round-level release, reusing the threaded roundNumber) so a consumer gates `venue_id`/`court_id` at read time — same model as `embargo`.

**#10 scheduled_date derivation** — a scheduledTime-only matchUp (full ISO datetime) gets `scheduledDate` derived by the inContext flatten; `matchUpScheduledDate` now derives it too so the slim MODIFY_MATCHUP result row can't clobber a flattened `scheduled_date` to null.

199 readModel+publishing tests + empirical parity vs getEventData; coverage gate passes; lint/types clean. Pairs with CFS + query PRs.