### PR TITLE
feat(types): value-export domain enums + enum/const conformance guard

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,45 @@ export * from './constants';
 // TYPES -----------------------------------------------------------------
 export type * from './types';
 
+// Enums are value-exported (runtime) IN ADDITION to the type-only `./types` surface
+// above, so consumers can reference members at runtime (e.g. `MatchUpStatusEnum.COMPLETED`),
+// not just type against them. These explicit named exports override the type-only star
+// re-export for the same names. They are kept in lock-step with the runtime string values
+// in `src/constants/*` by the enum/const conformance guard
+// (`src/tests/constants/enumConstConformance.test.ts`).
+export {
+  AddressTypeEnum,
+  BallTypeEnum,
+  CountryCodeEnum,
+  CourtPositionEnum,
+  DrawTypeEnum,
+  EntryStatusEnum,
+  FinishingPositionEnum,
+  LengthUnitEnum,
+  LinkTypeEnum,
+  MatchUpStatusEnum,
+  OnlineResourceTypeEnum,
+  ParticipantRoleEnum,
+  ParticipantStatusEnum,
+  ParticipantTypeEnum,
+  PenaltyTypeEnum,
+  PlayingDoubleHandCodeEnum,
+  PlayingHandCodeEnum,
+  PositioningProfileEnum,
+  SeedingProfileEnum,
+  SexEnum,
+  ShotDetailEnum,
+  ShotOutcomeEnum,
+  ShotTypeEnum,
+  StageTypeEnum,
+  StructureTypeEnum,
+  SurfaceCategoryEnum,
+  TournamentLevelEnum,
+  WeekdayEnum,
+  WheelchairClassEnum,
+  WinReasonEnum,
+} from './types/tournamentTypes';
+
 // Statistics types (top-level convenience re-exports)
 export type { StatObject, MatchStatistics, StatCounters, StatisticsOptions } from './query/scoring/statistics/types';
 export { toStatObjects } from './query/scoring/statistics/toStatObjects';

--- a/src/tests/constants/enumConstConformance.test.ts
+++ b/src/tests/constants/enumConstConformance.test.ts
@@ -1,0 +1,121 @@
+import * as drawDefinitionConstants from '@Constants/drawDefinitionConstants';
+import * as matchUpStatusConstants from '@Constants/matchUpStatusConstants';
+import * as participantConstants from '@Constants/participantConstants';
+import * as entryStatusConstants from '@Constants/entryStatusConstants';
+import * as weekdayConstants from '@Constants/weekdayConstants';
+import * as surfaceConstants from '@Constants/surfaceConstants';
+import * as genderConstants from '@Constants/genderConstants';
+import * as T from '@Types/tournamentTypes';
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Enum ↔ const-module conformance guard (Layer 1).
+ *
+ * factory now value-exports the `*Enum`s from `src/types/tournamentTypes.ts`
+ * (runtime, e.g. `MatchUpStatusEnum.COMPLETED`) IN ADDITION to the runtime string
+ * values in `src/constants/*`. For the concepts that have BOTH, that is two runtime
+ * sources of the same strings — this guard makes divergence a CI failure so the two
+ * can be maintained safely.
+ *
+ * Two invariants, matching how the constants surface is actually shaped:
+ *  - MIRRORS: a const module whose string exports are a DEDICATED 1:1 image of an
+ *    enum — assert exact key AND value parity in both directions.
+ *  - COVERAGE: an enum whose members live inside a BROADER const bucket (e.g. stage
+ *    / structure / seeding all sit in drawDefinitionConstants) — assert every enum
+ *    VALUE is backed by a const value in that bucket (no enum member without a const).
+ *
+ * Enums with NO const twin are enum-only (a single source — nothing to guard); they
+ * are listed in ENUM_ONLY so the coverage is explicit and adding a new enum forces a
+ * deliberate "mirror, bucket, or enum-only?" decision here.
+ */
+
+const stringEntries = (mod: Record<string, unknown>): Record<string, string> => {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(mod)) if (typeof v === 'string') out[k] = v;
+  return out;
+};
+const enumEntries = (e: Record<string, unknown>): Record<string, string> => stringEntries(e);
+const valuesOf = (mod: Record<string, unknown>): Set<string> => new Set(Object.values(stringEntries(mod)));
+
+// ── Dedicated 1:1 mirrors — exact key + value parity ─────────────────────────
+const MIRRORS: { name: string; enum: Record<string, unknown>; consts: Record<string, unknown> }[] = [
+  { name: 'MatchUpStatus', enum: T.MatchUpStatusEnum, consts: matchUpStatusConstants },
+  { name: 'EntryStatus', enum: T.EntryStatusEnum, consts: entryStatusConstants },
+  { name: 'SurfaceCategory', enum: T.SurfaceCategoryEnum, consts: surfaceConstants },
+  { name: 'Weekday', enum: T.WeekdayEnum, consts: weekdayConstants },
+];
+
+// ── Bucket coverage — every enum value backed by a const value in the bucket ──
+const COVERAGE: { name: string; enum: Record<string, unknown>; consts: Record<string, unknown> }[] = [
+  { name: 'StageType', enum: T.StageTypeEnum, consts: drawDefinitionConstants },
+  { name: 'StructureType', enum: T.StructureTypeEnum, consts: drawDefinitionConstants },
+  { name: 'SeedingProfile', enum: T.SeedingProfileEnum, consts: drawDefinitionConstants },
+  { name: 'FinishingPosition', enum: T.FinishingPositionEnum, consts: drawDefinitionConstants },
+  { name: 'ParticipantType', enum: T.ParticipantTypeEnum, consts: participantConstants },
+  { name: 'Sex', enum: T.SexEnum, consts: genderConstants },
+];
+
+// Enum-only: no const-module twin (single source of truth — nothing to reconcile).
+// Listed so a newly-added enum can't silently skip the mirror/bucket decision above.
+const ENUM_ONLY = [
+  'AddressTypeEnum',
+  'BallTypeEnum',
+  'CountryCodeEnum',
+  'CourtPositionEnum',
+  'DrawTypeEnum',
+  'LengthUnitEnum',
+  'LinkTypeEnum',
+  'OnlineResourceTypeEnum',
+  'ParticipantRoleEnum',
+  'ParticipantStatusEnum',
+  'PenaltyTypeEnum',
+  'PlayingDoubleHandCodeEnum',
+  'PlayingHandCodeEnum',
+  'PositioningProfileEnum',
+  'ShotDetailEnum',
+  'ShotOutcomeEnum',
+  'ShotTypeEnum',
+  'TournamentLevelEnum',
+  'WheelchairClassEnum',
+  'WinReasonEnum',
+];
+
+describe('enum ↔ const conformance guard', () => {
+  describe.each(MIRRORS)('$name (dedicated mirror)', ({ enum: e, consts }) => {
+    const en = enumEntries(e);
+    const co = stringEntries(consts);
+
+    it('the enum and its const module share the exact same keys', () => {
+      expect(Object.keys(en).sort()).toEqual(Object.keys(co).sort());
+    });
+
+    it('every shared key maps to the same value in both', () => {
+      for (const key of Object.keys(en)) expect(co[key]).toBe(en[key]);
+    });
+  });
+
+  describe.each(COVERAGE)('$name (bucket coverage)', ({ enum: e, consts }) => {
+    it('every enum value is backed by a const value in the bucket', () => {
+      const bucket = valuesOf(consts);
+      const missing = Object.values(enumEntries(e)).filter((v) => !bucket.has(v));
+      expect(missing).toEqual([]);
+    });
+  });
+
+  it('every value-exported enum is accounted for (mirror, bucket, or enum-only)', () => {
+    // registry display names are the enum export names minus the `Enum` suffix.
+    const accounted = new Set([
+      ...MIRRORS.map((m) => `${m.name}Enum`),
+      ...COVERAGE.map((c) => `${c.name}Enum`),
+      ...ENUM_ONLY,
+    ]);
+    // every real enum object exported from tournamentTypes must be accounted for above,
+    // so a newly-added enum forces a deliberate mirror/bucket/enum-only decision here.
+    const allEnums = Object.keys(T).filter((k) => {
+      const v = (T as any)[k];
+      return k.endsWith('Enum') && v && typeof v === 'object' && Object.values(v).some((x) => typeof x === 'string');
+    });
+    const unaccounted = allEnums.filter((name) => !accounted.has(name));
+    expect({ unaccounted }).toEqual({ unaccounted: [] });
+  });
+});


### PR DESCRIPTION
For ClubSpark (and any consumer extending factory): make the `*Enum`s usable at **runtime**, not just as types — with a guardrail so the two runtime sources of the same strings can't drift.

## (a) Value-export the enums
`tournamentTypes.ts`'s enums were only reachable as **types**: the barrel re-exports `./types` via `export type *`, which strips the runtime side. So `MatchUpStatusEnum` typed fine but `MatchUpStatusEnum.COMPLETED` was `undefined` at runtime; runtime values were only available (weakly, as `any`) via `src/constants/*`.

Now all 29 enums + the `DrawTypeEnum` const-object are value-exported alongside the type-only surface (named exports override the type-only star; verified no collisions). Union types (`MatchUpStatusUnion`, …) stay correctly type-only. Verified against the built package: `MatchUpStatusEnum.COMPLETED === 'COMPLETED'`, `CountryCodeEnum.USA`, `DrawTypeEnum` (22 keys), etc.

## Layer 1 — enum/const conformance guard
`src/tests/constants/enumConstConformance.test.ts` makes divergence between the enums and the `src/constants/*` string modules a CI failure:
- **Dedicated mirrors** (matchUpStatus, entryStatus, surface, weekday) — exact key + value parity, both directions.
- **Bucket coverage** (stage / structure / seeding / finishing ⊆ `drawDefinitionConstants`, participantType ⊆ `participantConstants`, sex ⊆ `genderConstants`) — every enum value backed by a const.
- **Coverage assertion** — every value-exported enum must be accounted for (mirror / bucket / the 20 enum-only), so a new enum can't silently skip the decision.

Teeth-verified (desyncing a const value fails it). All pairs are already in sync today, so it starts green.

Full vitest suite + coverage gate (95/95/85/85), `test:server` (9/12), lint, check-types — all green. Factory-only; additive to the public API (no consumer breakage).

Next (separate, deliberate): (b) type the const modules, then optionally collapse to a single derived source.